### PR TITLE
Add remembered people, cross-channel messaging, and channel-aware wake handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
 DISCORD_TOKEN=your_discord_bot_token
 OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-5.4-mini
+OPENAI_INTERNAL_MODEL=gpt-5.4-nano
 OPENAI_DAILY_BUDGET_USD=0
-KNOWN_PEOPLE={"makandz":"Makan"}
-# Optional: set this to send "Hello!" to a server text channel on startup.
-DISCORD_CHANNEL_ID=
+OPENAI_USAGE_LOG_DIR=logs/openai-usage
+BOT_INTERNAL_STATE_PATH=logs/internal-state.json
+BOT_CONVERSATION_SUMMARY_PATH=logs/conversation-summaries.json
+BOT_KNOWN_PEOPLE_PATH=logs/known-people.json
+DISCORD_LOG_CHANNEL_ID=
+LOG_LEVEL=info
+LOG_PROMPTS=false
+BOT_MESSAGE_DEBOUNCE_MS=5000
+BOT_TYPING_DEBOUNCE_MS=10000
+BOT_IDLE_SLEEP_MS=300000
+BOT_INTERNAL_ACTION_INTERVAL_MS=86400000

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ TypeScript Discord bot that wakes on a ping, batches recent human messages, and 
    pnpm dev
    ```
 
-The bot logs when it connects. It replies in the channel where the triggering message batch was received. Status messages such as wake, wait, sleep, and reasoning summaries are sent to `DISCORD_LOG_CHANNEL_ID` when configured.
+The bot logs when it connects. It replies in the channel where the triggering message batch was received, and can route requested messages to another server channel by name. Ben stays active in one channel at a time; pings from other channels are queued until the current channel sleeps. Status messages such as wake, wait, sleep, and reasoning summaries are sent to `DISCORD_LOG_CHANNEL_ID` when configured.
 
 ## Internal Actions
 
@@ -61,14 +61,13 @@ The last status is stored in a separate JSON file at `logs/internal-state.json` 
 - `OPENAI_DAILY_BUDGET_USD` defaults to `0`, which disables the daily cost stop. Set it to a positive dollar amount to stop OpenAI calls after that day's stored usage reaches the limit.
 - `OPENAI_USAGE_LOG_DIR` defaults to `logs/openai-usage`. Usage is stored in monthly `YYMM.json` files with daily buckets.
 - `BOT_INTERNAL_STATE_PATH` defaults to `logs/internal-state.json`. Internal action state is stored separately from usage.
+- `BOT_KNOWN_PEOPLE_PATH` defaults to `logs/known-people.json`. The bot stores remembered Discord users and names there after validating them against the server.
 - `DISCORD_LOG_CHANNEL_ID` optionally enables internal action log lines, wake/wait/sleep status messages, and reasoning summaries in a dedicated Discord channel.
-- `KNOWN_PEOPLE` maps Discord usernames to real names in prompts, for example `{"makandz":"Makan"}`. Known users are shown as `makandz (Makan): ...`; unknown users stay as `username: ...`.
 - `LOG_LEVEL` defaults to `info`; use `debug` for queue and debounce details.
 - `LOG_PROMPTS=true` logs full prompts at debug level.
 - `BOT_MESSAGE_DEBOUNCE_MS` defaults to `5000`. After the latest human message, the bot waits this long before calling OpenAI.
 - `BOT_TYPING_DEBOUNCE_MS` defaults to `10000`. Each Discord typing indicator keeps that user active for this long unless they send a message first.
-- `BOT_IDLE_SLEEP_MS` defaults to `600000`.
-- `BOT_MESSAGE_LINE_DELAY_MS` defaults to `1000`; multi-line bot replies are sent one line at a time with this delay before each next line.
+- `BOT_IDLE_SLEEP_MS` defaults to `300000`.
 - `BOT_INTERNAL_ACTION_INTERVAL_MS` defaults to `86400000`.
 
 The system prompt is loaded from `src/prompts/system.txt` on each OpenAI request, so edits are picked up without restarting the bot.

--- a/src/bot/BotSession.ts
+++ b/src/bot/BotSession.ts
@@ -1,9 +1,17 @@
 import type { AppConfig } from "../config.js";
 import type { Logger } from "../logger.js";
 import type { OpenAIResponder } from "../openai/responder.js";
-import type { ApiMemory, ResponderResult } from "../openai/types.js";
+import type {
+  ApiMemory,
+  RememberPersonToolInput,
+  RememberPersonToolResult,
+  ResponderResult,
+  SendChannelMessageToolInput,
+  SendChannelMessageToolResult,
+} from "../openai/types.js";
 import type { ConversationSummaryStore } from "./conversationSummaryStore.js";
 import { buildUserPrompt } from "./formatMessages.js";
+import type { KnownPeopleStore } from "./knownPeopleStore.js";
 import type { BotMode, HumanMessage } from "./types.js";
 
 type SendMessageToChannel = (channelId: string, text: string) => Promise<void>;
@@ -12,16 +20,32 @@ type SendTypingToChannel = (channelId: string) => Promise<void>;
 type ReactToMessage = (channelId: string, messageId: string, emoji: string) => Promise<void>;
 type GetCurrentActivityStatus = () => string | undefined;
 type SetAwakePresence = (awake: boolean) => void;
+type RememberPerson = (
+  input: RememberPersonToolInput,
+  channelId: string | undefined,
+) => Promise<RememberPersonToolResult>;
+type SendChannelMessage = (
+  input: SendChannelMessageToolInput,
+  activeChannelId: string | undefined,
+) => Promise<SendChannelMessageToolResult>;
 
 interface TypingActivity {
   expiresAt: number;
 }
 
+interface QueuedWakeRequest {
+  channelId: string;
+  messages: HumanMessage[];
+  recentContext: HumanMessage[];
+}
+
 export class BotSession {
   private mode: BotMode = "sleeping";
-  private sleepFifo: HumanMessage[] = [];
+  private activeChannelId: string | undefined;
+  private sleepFifoByChannel = new Map<string, HumanMessage[]>();
   private pendingBatch: HumanMessage[] = [];
   private queuedWhileProcessing: HumanMessage[] = [];
+  private queuedWakeRequests: QueuedWakeRequest[] = [];
   private apiMemory: ApiMemory = [];
   private recentContextForPendingBatch: HumanMessage[] = [];
   private channelLastMessageAt = new Map<string, number>();
@@ -39,29 +63,70 @@ export class BotSession {
     private readonly getCurrentActivityStatus: GetCurrentActivityStatus,
     private readonly setAwakePresence: SetAwakePresence,
     private readonly conversationSummaryStore: ConversationSummaryStore,
+    private readonly knownPeopleStore: KnownPeopleStore,
+    private readonly rememberPerson: RememberPerson,
+    private readonly sendChannelMessage: SendChannelMessage,
     private readonly logger: Logger,
   ) {}
 
   handleMessage(message: HumanMessage, ping: boolean): void {
     this.markMessageActivity(message);
+    const recentContext = this.getSleepFifo(message.channelId);
 
     if (this.mode === "sleeping") {
-      const recentContext = [...this.sleepFifo];
       this.addToSleepFifo(message);
 
       if (!ping) {
         this.logger.debug("fifo.message", {
+          channelId: message.channelId,
           username: message.username,
-          fifoCount: this.sleepFifo.length,
+          fifoCount: this.getSleepFifo(message.channelId).length,
         });
         return;
       }
 
-      this.wake(message, recentContext);
+      this.wake([message], recentContext);
       return;
     }
 
     this.addToSleepFifo(message);
+
+    if (message.channelId !== this.activeChannelId) {
+      const queuedWakeRequest = this.queuedWakeRequests.find(
+        (request) => request.channelId === message.channelId,
+      );
+
+      if (queuedWakeRequest !== undefined) {
+        queuedWakeRequest.messages.push(message);
+        this.logger.info("wake_queue.message_added", {
+          channelId: message.channelId,
+          username: message.username,
+          messages: queuedWakeRequest.messages.length,
+        });
+        return;
+      }
+
+      if (ping) {
+        this.queuedWakeRequests.push({
+          channelId: message.channelId,
+          messages: [message],
+          recentContext,
+        });
+        this.logger.info("wake_queue.queued", {
+          channelId: message.channelId,
+          username: message.username,
+          queuedChannels: this.queuedWakeRequests.length,
+        });
+      } else {
+        this.logger.debug("fifo.other_channel_message", {
+          activeChannelId: this.activeChannelId,
+          channelId: message.channelId,
+          username: message.username,
+        });
+      }
+
+      return;
+    }
 
     if (this.mode === "processing") {
       this.queuedWhileProcessing.push(message);
@@ -112,20 +177,29 @@ export class BotSession {
     this.resetIdleSleepTimer();
   }
 
-  private wake(message: HumanMessage, recentContext: HumanMessage[]): void {
+  private wake(messages: HumanMessage[], recentContext: HumanMessage[]): void {
+    const firstMessage = messages[0];
+
+    if (firstMessage === undefined) {
+      return;
+    }
+
     this.mode = "awake";
+    this.activeChannelId = firstMessage.channelId;
     this.setAwakePresence(true);
-    this.pendingBatch = [message];
+    this.pendingBatch = messages;
     this.recentContextForPendingBatch = recentContext;
     this.apiMemory = [];
     this.queuedWhileProcessing = [];
 
     this.logger.info("mode.wake", {
-      by: message.username,
+      channelId: firstMessage.channelId,
+      by: firstMessage.username,
+      messages: messages.length,
       contextCount: recentContext.length,
     });
 
-    void this.sendStatusMessage("Woke up from a ping", message.channelId);
+    void this.sendStatusMessage("Woke up from a ping", firstMessage.channelId);
     this.scheduleDebounce();
     this.resetIdleSleepTimer();
   }
@@ -290,10 +364,14 @@ export class BotSession {
     const recentConversationSummaries = includeFirstPromptContext
       ? await this.conversationSummaryStore.list()
       : [];
+    const knownPeople = await this.knownPeopleStore.listForPrompt().catch((error: unknown) => {
+      this.logger.warn("known_people.read_failed", { error: String(error) });
+      return {};
+    });
     const promptOptions: Parameters<typeof buildUserPrompt>[0] = {
       recentContext,
       messages,
-      knownPeople: this.config.knownPeople,
+      knownPeople,
       includeKnownPeople: includeFirstPromptContext,
       recentConversationSummaries,
     };
@@ -323,7 +401,18 @@ export class BotSession {
     const stopTyping = this.startTyping(responseChannelId);
 
     try {
-      const result = await this.responder.respond(userPrompt, this.apiMemory);
+      const result = await this.responder.respond(userPrompt, this.apiMemory, {
+        rememberPerson: (input) => this.rememberPerson(input, responseChannelId),
+        sendChannelMessage: async (input) => {
+          const result = await this.sendChannelMessage(input, responseChannelId);
+
+          if (result.ok) {
+            this.addBotMessageToSleepFifo(result.channelId, input.text);
+          }
+
+          return result;
+        },
+      });
       await this.handleResponderResult(result, responseChannelId, reactionTargetMessageId);
     } finally {
       stopTyping();
@@ -524,6 +613,7 @@ export class BotSession {
     }
 
     this.mode = "sleeping";
+    this.activeChannelId = undefined;
     this.setAwakePresence(false);
     this.pendingBatch = [];
     this.queuedWhileProcessing = [];
@@ -533,16 +623,62 @@ export class BotSession {
 
     this.logger.info("mode.sleep", {
       reason,
-      fifoCount: this.sleepFifo.length,
+      queuedWakeRequests: this.queuedWakeRequests.length,
     });
+
+    this.wakeNextQueuedChannel();
   }
 
   private addToSleepFifo(message: HumanMessage): void {
-    this.sleepFifo.push(message);
+    const fifo = this.sleepFifoByChannel.get(message.channelId) ?? [];
+    fifo.push(message);
 
-    if (this.sleepFifo.length > 5) {
-      this.sleepFifo.shift();
+    if (fifo.length > 5) {
+      fifo.shift();
     }
+
+    this.sleepFifoByChannel.set(message.channelId, fifo);
+  }
+
+  private getSleepFifo(channelId: string): HumanMessage[] {
+    return [...(this.sleepFifoByChannel.get(channelId) ?? [])];
+  }
+
+  private addBotMessageToSleepFifo(channelId: string, content: string): void {
+    const message: HumanMessage = {
+      id: `ben:${String(Date.now())}:${String(Math.random())}`,
+      channelId,
+      userId: "ben",
+      username: "Ben",
+      content,
+      createdAt: Date.now(),
+    };
+
+    this.addToSleepFifo(message);
+
+    const queuedWakeRequest = this.queuedWakeRequests.find(
+      (request) => request.channelId === channelId,
+    );
+
+    if (queuedWakeRequest !== undefined) {
+      queuedWakeRequest.messages.push(message);
+    }
+  }
+
+  private wakeNextQueuedChannel(): void {
+    const nextWakeRequest = this.queuedWakeRequests.shift();
+
+    if (nextWakeRequest === undefined) {
+      return;
+    }
+
+    this.logger.info("wake_queue.promoted", {
+      channelId: nextWakeRequest.channelId,
+      messages: nextWakeRequest.messages.length,
+      remainingQueuedChannels: this.queuedWakeRequests.length,
+    });
+
+    this.wake(nextWakeRequest.messages, nextWakeRequest.recentContext);
   }
 }
 

--- a/src/bot/knownPeopleStore.ts
+++ b/src/bot/knownPeopleStore.ts
@@ -1,0 +1,190 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { KnownPerson } from "../config.js";
+import type { Logger } from "../logger.js";
+
+interface StoredKnownPerson {
+  username: string;
+  name: string;
+}
+
+interface KnownPeopleData {
+  people: Record<string, StoredKnownPerson>;
+}
+
+export interface RememberKnownPersonInput {
+  userId: string;
+  username: string;
+  name: string;
+}
+
+export type RememberKnownPersonResult =
+  | {
+      ok: true;
+      username: string;
+      name: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export class KnownPeopleStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly logger: Logger,
+  ) {}
+
+  async listForPrompt(): Promise<Record<string, KnownPerson>> {
+    const data = await this.read();
+    const knownPeople: Record<string, KnownPerson> = {};
+
+    for (const person of Object.values(data.people)) {
+      knownPeople[normalizeUsername(person.username)] = { name: person.name };
+    }
+
+    return knownPeople;
+  }
+
+  async remember(input: RememberKnownPersonInput): Promise<RememberKnownPersonResult> {
+    const userId = input.userId.trim();
+    const username = input.username.trim();
+    const normalizedUsername = normalizeUsername(username);
+    const name = input.name.trim();
+
+    if (userId.length === 0) {
+      return { ok: false, error: "missing Discord user ID" };
+    }
+
+    if (normalizedUsername.length === 0) {
+      return { ok: false, error: "missing Discord username" };
+    }
+
+    if (name.length === 0) {
+      return { ok: false, error: "missing name" };
+    }
+
+    const data = await this.read();
+    const existing = data.people[userId];
+
+    if (existing !== undefined) {
+      return {
+        ok: false,
+        error: `${existing.username} is already remembered as "${existing.name}"`,
+      };
+    }
+
+    for (const [existingUserId, person] of Object.entries(data.people)) {
+      if (
+        existingUserId !== userId &&
+        normalizeUsername(person.username) === normalizedUsername
+      ) {
+        return {
+          ok: false,
+          error: `${person.username} is already remembered as "${person.name}"`,
+        };
+      }
+    }
+
+    data.people[userId] = { username, name };
+    await this.write(data);
+
+    return { ok: true, username, name };
+  }
+
+  private async read(): Promise<KnownPeopleData> {
+    let raw: string;
+
+    try {
+      raw = await readFile(this.filePath, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return { people: {} };
+      }
+
+      throw error;
+    }
+
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(`${this.filePath} must contain valid JSON.`);
+    }
+
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error(`${this.filePath} must contain a JSON object.`);
+    }
+
+    const people = (parsed as { people?: unknown }).people;
+
+    if (people === undefined) {
+      return { people: {} };
+    }
+
+    if (people === null || Array.isArray(people) || typeof people !== "object") {
+      throw new Error(`${this.filePath} people must be a JSON object.`);
+    }
+
+    const data: KnownPeopleData = { people: {} };
+
+    for (const [userId, value] of Object.entries(people)) {
+      if (value === null || Array.isArray(value) || typeof value !== "object") {
+        this.logger.warn("known_people.invalid_entry_ignored", { userId });
+        continue;
+      }
+
+      const username = (value as { username?: unknown }).username;
+      const name = (value as { name?: unknown }).name;
+
+      if (typeof username !== "string" || typeof name !== "string") {
+        this.logger.warn("known_people.invalid_entry_ignored", { userId });
+        continue;
+      }
+
+      const normalizedUserId = userId.trim();
+      const trimmedUsername = username.trim();
+      const trimmedName = name.trim();
+
+      if (
+        normalizedUserId.length === 0 ||
+        trimmedUsername.length === 0 ||
+        trimmedName.length === 0
+      ) {
+        this.logger.warn("known_people.invalid_entry_ignored", { userId });
+        continue;
+      }
+
+      data.people[normalizedUserId] = {
+        username: trimmedUsername,
+        name: trimmedName,
+      };
+    }
+
+    return data;
+  }
+
+  private async write(data: KnownPeopleData): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await mkdir(dir, { recursive: true });
+
+    const tempPath = path.join(
+      dir,
+      `.${path.basename(this.filePath)}.${String(process.pid)}.${String(Date.now())}.tmp`,
+    );
+    const content = `${JSON.stringify(data, null, 2)}\n`;
+
+    await writeFile(tempPath, content, "utf8");
+    await rename(tempPath, this.filePath);
+  }
+}
+
+function normalizeUsername(username: string): string {
+  return username.trim().toLowerCase();
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,14 +13,13 @@ export interface AppConfig {
   openaiUsageLogDir: string;
   internalStatePath: string;
   conversationSummaryPath: string;
+  knownPeoplePath: string;
   discordLogChannelId: string | undefined;
-  knownPeople: Record<string, KnownPerson>;
   logLevel: LogLevel;
   logPrompts: boolean;
   messageDebounceMs: number;
   typingDebounceMs: number;
   idleSleepMs: number;
-  messageLineDelayMs: number;
   internalActionIntervalMs: number;
 }
 
@@ -62,69 +61,6 @@ function readLogLevel(): LogLevel {
   return value as LogLevel;
 }
 
-function readKnownPeople(): Record<string, KnownPerson> {
-  const value = process.env.KNOWN_PEOPLE;
-
-  if (!value) {
-    return {};
-  }
-
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error(
-      'KNOWN_PEOPLE must be valid JSON, like {"makandz":"Makan"}.',
-    );
-  }
-
-  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
-    throw new Error(
-      "KNOWN_PEOPLE must be a JSON object mapping Discord usernames to names.",
-    );
-  }
-
-  const knownPeople: Record<string, KnownPerson> = {};
-
-  for (const [username, value] of Object.entries(parsed)) {
-    const normalizedUsername = username.trim().toLowerCase();
-
-    if (normalizedUsername.length === 0) {
-      throw new Error("KNOWN_PEOPLE must use non-empty Discord usernames.");
-    }
-
-    if (typeof value === "string") {
-      const name = value.trim();
-
-      if (name.length === 0) {
-        throw new Error(
-          "KNOWN_PEOPLE string entries must use non-empty names.",
-        );
-      }
-
-      knownPeople[normalizedUsername] = { name };
-      continue;
-    }
-
-    if (typeof value !== "string") {
-      throw new Error("KNOWN_PEOPLE must map Discord usernames to names.");
-    }
-
-    const name = value.trim();
-
-    if (name.length === 0) {
-      throw new Error(
-        "KNOWN_PEOPLE must map non-empty Discord usernames to non-empty names.",
-      );
-    }
-
-    knownPeople[normalizedUsername] = { name };
-  }
-
-  return knownPeople;
-}
-
 export function loadConfig(): AppConfig {
   return {
     discordToken: requireEnv("DISCORD_TOKEN"),
@@ -137,14 +73,13 @@ export function loadConfig(): AppConfig {
       process.env.BOT_INTERNAL_STATE_PATH ?? "logs/internal-state.json",
     conversationSummaryPath:
       process.env.BOT_CONVERSATION_SUMMARY_PATH ?? "logs/conversation-summaries.json",
+    knownPeoplePath: process.env.BOT_KNOWN_PEOPLE_PATH ?? "logs/known-people.json",
     discordLogChannelId: process.env.DISCORD_LOG_CHANNEL_ID,
-    knownPeople: readKnownPeople(),
     logLevel: readLogLevel(),
     logPrompts: process.env.LOG_PROMPTS === "true",
     messageDebounceMs: readNumberEnv("BOT_MESSAGE_DEBOUNCE_MS", 5_000),
     typingDebounceMs: readNumberEnv("BOT_TYPING_DEBOUNCE_MS", 10_000),
-    idleSleepMs: readNumberEnv("BOT_IDLE_SLEEP_MS", 10 * 60 * 1_000),
-    messageLineDelayMs: readNumberEnv("BOT_MESSAGE_LINE_DELAY_MS", 1_000),
+    idleSleepMs: readNumberEnv("BOT_IDLE_SLEEP_MS", 5 * 60 * 1_000),
     internalActionIntervalMs: readNumberEnv(
       "BOT_INTERNAL_ACTION_INTERVAL_MS",
       24 * 60 * 60 * 1_000,

--- a/src/discord/mentions.ts
+++ b/src/discord/mentions.ts
@@ -1,8 +1,10 @@
 import type { Message, User } from "discord.js";
 
 const DISCORD_USER_MENTION_PATTERN = /<@!?(\d+)>/g;
+const DISCORD_CHANNEL_MENTION_PATTERN = /<#(\d+)>/g;
 const BROADCAST_MENTION_PATTERN = /@(?=everyone\b|here\b)/gi;
 const USERNAME_MENTION_PATTERN = /(^|[^\w@.])@([a-z0-9_]{2,32})(?![\w.])/gi;
+const CHANNEL_NAME_PATTERN = /(^|[^\w#<])#([a-z0-9_-]{1,100})(?![\w-])/gi;
 
 export function escapeBroadcastMentions(content: string): string {
   return content.replace(BROADCAST_MENTION_PATTERN, "@\u200B");
@@ -77,8 +79,81 @@ export class UserMentionDirectory {
   }
 }
 
+export class ChannelMentionDirectory {
+  private readonly idToName = new Map<string, string>();
+  private readonly nameToId = new Map<string, string>();
+
+  rememberChannel(channel: { id: string; name?: string | null }): void {
+    if (typeof channel.name !== "string" || channel.name.length === 0) {
+      return;
+    }
+
+    this.idToName.set(channel.id, channel.name);
+    this.nameToId.set(normalizeChannelName(channel.name), channel.id);
+  }
+
+  rememberMessageChannels(message: Message): void {
+    this.rememberChannel(message.channel);
+
+    for (const channel of message.mentions.channels.values()) {
+      this.rememberChannel(channel);
+    }
+  }
+
+  convertMentionsToNames(content: string): string {
+    return content.replace(DISCORD_CHANNEL_MENTION_PATTERN, (mention, channelId: string) => {
+      const name = this.idToName.get(channelId);
+
+      return name === undefined ? mention : `#${name}`;
+    });
+  }
+
+  convertNamesToMentions(content: string): string {
+    let converted = content;
+    const channelNames = [...this.nameToId.keys()].sort(
+      (left, right) => right.length - left.length,
+    );
+
+    for (const channelName of channelNames) {
+      const channelId = this.nameToId.get(channelName);
+
+      if (channelId === undefined) {
+        continue;
+      }
+
+      converted = converted.replace(channelMentionPattern(channelName), `$1<#${channelId}>`);
+    }
+
+    return converted;
+  }
+
+  findUnresolvedChannelNames(content: string): string[] {
+    const channelNames = new Set<string>();
+
+    for (const match of content.matchAll(CHANNEL_NAME_PATTERN)) {
+      const channelName = match[2];
+
+      if (channelName === undefined) {
+        continue;
+      }
+
+      const normalizedChannelName = normalizeChannelName(channelName);
+
+      if (!this.nameToId.has(normalizedChannelName)) {
+        channelNames.add(normalizedChannelName);
+      }
+    }
+
+    return [...channelNames];
+  }
+}
+
 function normalizeUsername(username: string): string {
   return username.toLowerCase();
+}
+
+function normalizeChannelName(channelName: string): string {
+  return channelName.toLowerCase();
 }
 
 function usernameMentionPattern(username: string): RegExp {
@@ -87,6 +162,10 @@ function usernameMentionPattern(username: string): RegExp {
 
 function usernameMentionTagPattern(username: string): RegExp {
   return new RegExp(`<@${escapeRegExp(username)}>`, "gi");
+}
+
+function channelMentionPattern(channelName: string): RegExp {
+  return new RegExp(`(^|[^\\w#<])#${escapeRegExp(channelName)}(?![\\w-])`, "gi");
 }
 
 function escapeRegExp(text: string): string {

--- a/src/discord/message.ts
+++ b/src/discord/message.ts
@@ -1,25 +1,28 @@
 import type { Client, Message } from "discord.js";
 
 import type { HumanMessage } from "../bot/types.js";
-import type { UserMentionDirectory } from "./mentions.js";
+import type { ChannelMentionDirectory, UserMentionDirectory } from "./mentions.js";
 
 export function toHumanMessage(
   message: Message,
   client: Client,
   mentionDirectory: UserMentionDirectory,
+  channelDirectory: ChannelMentionDirectory,
 ): HumanMessage | null {
   if (message.author.bot || message.author.id === client.user?.id) {
     return null;
   }
 
   mentionDirectory.rememberMessageUsers(message);
+  channelDirectory.rememberMessageChannels(message);
+  const contentWithUsernames = mentionDirectory.convertMentionsToUsernames(message.content);
 
   return {
     id: message.id,
     channelId: message.channelId,
     userId: message.author.id,
     username: message.author.username,
-    content: mentionDirectory.convertMentionsToUsernames(message.content),
+    content: channelDirectory.convertMentionsToNames(contentWithUsernames),
     createdAt: message.createdTimestamp,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,30 @@
 import "dotenv/config";
 
-import { Events, type GuildMember } from "discord.js";
+import { Events, type Guild, type GuildMember, type NonThreadGuildBasedChannel } from "discord.js";
 
 import { BotSession } from "./bot/BotSession.js";
 import { ConversationSummaryStore } from "./bot/conversationSummaryStore.js";
+import { KnownPeopleStore } from "./bot/knownPeopleStore.js";
 import { loadConfig } from "./config.js";
 import { createDiscordClient } from "./discord/client.js";
 import { isPing, toHumanMessage } from "./discord/message.js";
-import { escapeBroadcastMentions, UserMentionDirectory } from "./discord/mentions.js";
+import {
+  ChannelMentionDirectory,
+  escapeBroadcastMentions,
+  UserMentionDirectory,
+} from "./discord/mentions.js";
 import { handleUsageCommand, registerUsageCommand } from "./discord/usageCommand.js";
 import { InternalActionRunner } from "./internal/actions.js";
 import { InternalActionScheduler } from "./internal/scheduler.js";
 import { InternalStateStore } from "./internal/stateStore.js";
 import { Logger } from "./logger.js";
 import { OpenAIResponder } from "./openai/responder.js";
+import type {
+  RememberPersonToolInput,
+  RememberPersonToolResult,
+  SendChannelMessageToolInput,
+  SendChannelMessageToolResult,
+} from "./openai/types.js";
 import { OpenAIUsageStore } from "./openai/usageStore.js";
 
 const config = loadConfig();
@@ -24,10 +35,12 @@ const conversationSummaryStore = new ConversationSummaryStore(
   config.conversationSummaryPath,
   logger,
 );
+const knownPeopleStore = new KnownPeopleStore(config.knownPeoplePath, logger);
 const responder = new OpenAIResponder(config, logger, usageStore);
 const internalActionRunner = new InternalActionRunner(config, logger, usageStore);
 const internalStateStore = new InternalStateStore(config.internalStatePath, logger);
 const mentionDirectory = new UserMentionDirectory();
+const channelDirectory = new ChannelMentionDirectory();
 const sendLogMessage = async (text: string): Promise<boolean> => {
   if (config.discordLogChannelId === undefined) {
     return false;
@@ -62,22 +75,7 @@ const internalActionScheduler = new InternalActionScheduler(
 const session = new BotSession(
   config,
   responder,
-  async (channelId, text) => {
-    const channel = await client.channels.fetch(channelId);
-
-    if (!channel?.isSendable()) {
-      throw new Error("Response channel is not sendable.");
-    }
-
-    const safeText = escapeBroadcastMentions(text);
-    await resolveUnknownMentions(channel, safeText);
-    await channel.send({
-      content: escapeBroadcastMentions(mentionDirectory.convertUsernamesToMentions(safeText)),
-      allowedMentions: {
-        parse: ["users"],
-      },
-    });
-  },
+  sendDiscordMessage,
   async (text, fallbackChannelId) => {
     const sentToLog = await sendLogMessage(text);
 
@@ -122,6 +120,9 @@ const session = new BotSession(
     internalActionScheduler.setAwakePresence(awake);
   },
   conversationSummaryStore,
+  knownPeopleStore,
+  rememberPersonInChannel,
+  sendMessageToNamedChannel,
   logger,
 );
 
@@ -136,7 +137,7 @@ client.once(Events.ClientReady, (readyClient) => {
 });
 
 client.on(Events.MessageCreate, (message) => {
-  const humanMessage = toHumanMessage(message, client, mentionDirectory);
+  const humanMessage = toHumanMessage(message, client, mentionDirectory, channelDirectory);
 
   if (humanMessage === null) {
     return;
@@ -153,6 +154,7 @@ client.on(Events.TypingStart, (typing) => {
   }
 
   mentionDirectory.rememberUser(user);
+  channelDirectory.rememberChannel(typing.channel);
   session.handleTyping(typing.channel.id, user.id, user.username);
 });
 
@@ -179,6 +181,99 @@ process.once("SIGTERM", () => {
 });
 
 await client.login(config.discordToken);
+
+async function sendDiscordMessage(channelId: string, text: string): Promise<void> {
+  const channel = await client.channels.fetch(channelId);
+
+  if (!channel?.isSendable()) {
+    throw new Error("Response channel is not sendable.");
+  }
+
+  channelDirectory.rememberChannel(channel);
+
+  const safeText = escapeBroadcastMentions(text);
+  await resolveUnknownMentions(channel, safeText);
+  await resolveUnknownChannels(channel, safeText);
+  const contentWithChannelMentions = channelDirectory.convertNamesToMentions(safeText);
+  const contentWithUserMentions = mentionDirectory.convertUsernamesToMentions(
+    contentWithChannelMentions,
+  );
+
+  await channel.send({
+    content: escapeBroadcastMentions(contentWithUserMentions),
+    allowedMentions: {
+      parse: ["users"],
+    },
+  });
+}
+
+async function sendMessageToNamedChannel(
+  input: SendChannelMessageToolInput,
+  activeChannelId: string | undefined,
+): Promise<SendChannelMessageToolResult> {
+  const channelName = sanitizeChannelName(input.channel);
+  const fail = async (error: string): Promise<SendChannelMessageToolResult> => {
+    await sendChannelMessageFailureStatus(channelName, error, activeChannelId);
+    return { ok: false, error };
+  };
+
+  if (channelName.length === 0) {
+    return fail("channel must be non-empty");
+  }
+
+  if (input.text.trim().length === 0) {
+    return fail("message text must be non-empty");
+  }
+
+  if (activeChannelId === undefined) {
+    return fail("no active Discord channel");
+  }
+
+  try {
+    const activeChannel = await client.channels.fetch(activeChannelId);
+
+    if (activeChannel === null || !("guild" in activeChannel)) {
+      return await fail("active channel is not in a server");
+    }
+
+    const targetChannel = await findMatchingGuildChannel(activeChannel.guild, channelName);
+
+    if (targetChannel === undefined) {
+      return await fail("no matching server channel found");
+    }
+
+    channelDirectory.rememberChannel(targetChannel);
+    await sendDiscordMessage(targetChannel.id, input.text);
+
+    return {
+      ok: true,
+      channel: targetChannel.name,
+      channelId: targetChannel.id,
+    };
+  } catch (error) {
+    const message = String(error);
+    await sendChannelMessageFailureStatus(channelName, message, activeChannelId);
+    return { ok: false, error: message };
+  }
+}
+
+async function sendChannelMessageFailureStatus(
+  channelName: string,
+  error: string,
+  activeChannelId: string | undefined,
+): Promise<void> {
+  if (activeChannelId === undefined) {
+    logger.warn("discord.cross_channel_send_status_failed", {
+      error: "Cannot send cross-channel failure status without a channel ID.",
+    });
+    return;
+  }
+
+  await sendRememberStatus(
+    `> ⚠️ Failed to send message to #${channelName}: ${error}`,
+    activeChannelId,
+  );
+}
 
 async function resolveUnknownMentions(
   channel: Awaited<ReturnType<typeof client.channels.fetch>>,
@@ -212,6 +307,32 @@ async function resolveUnknownMentions(
   }
 }
 
+async function resolveUnknownChannels(
+  channel: Awaited<ReturnType<typeof client.channels.fetch>>,
+  text: string,
+): Promise<void> {
+  if (channel === null || !("guild" in channel)) {
+    return;
+  }
+
+  const channelNames = channelDirectory.findUnresolvedChannelNames(text);
+
+  for (const channelName of channelNames) {
+    try {
+      const targetChannel = await findMatchingGuildChannel(channel.guild, channelName);
+
+      if (targetChannel === undefined) {
+        logger.debug("discord.channel_not_found", { channelName });
+        continue;
+      }
+
+      channelDirectory.rememberChannel(targetChannel);
+    } catch (error) {
+      logger.warn("discord.channel_lookup_failed", { channelName, error: String(error) });
+    }
+  }
+}
+
 function findMatchingMember(
   username: string,
   members: readonly GuildMember[],
@@ -228,4 +349,133 @@ function findMatchingMember(
   }
 
   return members.length === 1 ? members[0] : undefined;
+}
+
+async function findMatchingGuildChannel(
+  guild: Guild,
+  channelName: string,
+): Promise<NonThreadGuildBasedChannel | undefined> {
+  const normalizedChannelName = sanitizeChannelName(channelName).toLowerCase();
+  const channels = await guild.channels.fetch();
+  const matches = [...channels.values()].filter(
+    (channel): channel is NonThreadGuildBasedChannel =>
+      channel !== null &&
+      typeof channel.name === "string" &&
+      channel.name.toLowerCase() === normalizedChannelName,
+  );
+
+  if (matches.length === 1) {
+    return matches[0];
+  }
+
+  return undefined;
+}
+
+async function rememberPersonInChannel(
+  input: RememberPersonToolInput,
+  channelId: string | undefined,
+): Promise<RememberPersonToolResult> {
+  const username = sanitizeRememberText(input.username).replace(/^@+/, "");
+  const name = sanitizeRememberText(input.name);
+  const fail = async (error: string): Promise<RememberPersonToolResult> => {
+    await sendRememberStatus(
+      `> ⚠️ Failed to remember "${username}" as "${name}": ${error}`,
+      channelId,
+    );
+    return { ok: false, error };
+  };
+
+  if (username.length === 0 || name.length === 0) {
+    return fail("username and name must be non-empty");
+  }
+
+  if (channelId === undefined) {
+    return fail("no active Discord channel");
+  }
+
+  try {
+    const channel = await client.channels.fetch(channelId);
+
+    if (channel === null || !("guild" in channel)) {
+      return await fail("active channel is not in a server");
+    }
+
+    const members = await channel.guild.members.search({
+      query: username,
+      limit: 10,
+      cache: true,
+    });
+    const member = findMatchingMember(username, [...members.values()]);
+
+    if (member === undefined) {
+      return await fail("no matching server member found");
+    }
+
+    mentionDirectory.rememberUser(member.user);
+    mentionDirectory.rememberUsername(username, member.id);
+
+    const result = await knownPeopleStore.remember({
+      userId: member.id,
+      username: member.user.username,
+      name,
+    });
+
+    if (!result.ok) {
+      await sendRememberStatus(
+        `> ⚠️ Failed to remember "${username}" as "${name}": ${result.error}`,
+        channelId,
+      );
+      return result;
+    }
+
+    await sendRememberStatus(
+      `> 🧠 Remembering that "${result.username}" is "${result.name}"`,
+      channelId,
+    );
+    return result;
+  } catch (error) {
+    const message = String(error);
+    await sendRememberStatus(
+      `> ⚠️ Failed to remember "${username}" as "${name}": ${message}`,
+      channelId,
+    );
+    return { ok: false, error: message };
+  }
+}
+
+async function sendRememberStatus(
+  text: string,
+  channelId: string | undefined,
+): Promise<void> {
+  try {
+    if (channelId === undefined) {
+      logger.warn("discord.remember_status_failed", {
+        error: "Cannot send remember status without a channel ID.",
+      });
+      return;
+    }
+
+    const channel = await client.channels.fetch(channelId);
+
+    if (!channel?.isSendable()) {
+      throw new Error("Remember status channel is not sendable.");
+    }
+
+    await channel.send({
+      content: escapeBroadcastMentions(text),
+      allowedMentions: {
+        parse: [],
+      },
+    });
+  } catch (error) {
+    logger.warn("discord.remember_status_failed", { error: String(error) });
+  }
+}
+
+function sanitizeRememberText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function sanitizeChannelName(channelName: string): string {
+  return channelName.trim().replace(/^#+/, "").trim().toLowerCase();
 }

--- a/src/openai/responder.ts
+++ b/src/openai/responder.ts
@@ -10,7 +10,13 @@ import type { AppConfig } from "../config.js";
 import type { Logger } from "../logger.js";
 import { extractReasoningSummary } from "./reasoning.js";
 import { loadSystemPrompt } from "./systemPrompt.js";
-import type { ApiMemory, ResponderResult } from "./types.js";
+import type {
+  ApiMemory,
+  BotToolExecutor,
+  RememberPersonToolInput,
+  ResponderResult,
+  SendChannelMessageToolInput,
+} from "./types.js";
 import { getModelPricing } from "./pricing.js";
 import { OpenAIUsageStore } from "./usageStore.js";
 
@@ -26,7 +32,11 @@ export class OpenAIResponder {
     this.client = new OpenAI({ apiKey: config.openaiApiKey });
   }
 
-  async respond(userPrompt: string, memory: ApiMemory): Promise<ResponderResult> {
+  async respond(
+    userPrompt: string,
+    memory: ApiMemory,
+    toolExecutor: BotToolExecutor,
+  ): Promise<ResponderResult> {
     const userItem = createUserMessageItem(userPrompt);
     const turnItems: ResponseInputItem[] = [userItem];
     const instructions = await loadSystemPrompt(this.logger);
@@ -59,69 +69,116 @@ export class OpenAIResponder {
         };
       }
 
-      const input: ResponseInputItem[] = [...memory, ...turnItems];
-      const response = await this.client.responses.create({
-        model: this.config.openaiModel,
-        instructions,
-        input,
-        tools: botControlTools,
-        tool_choice: "required",
-        max_output_tokens: 512,
-        reasoning: { effort: "low", summary: "concise" },
-        include: ["reasoning.encrypted_content"],
-        store: false,
-      });
-
-      if (response.usage !== undefined) {
-        const usage = await this.usageStore.record(this.config.openaiModel, response.usage);
-
-        this.logger.info("openai.usage", {
-          day: usage.day,
-          costUsd: usage.costUsd,
-          totalCostUsd: usage.totalCostUsd,
-          inputTokens: usage.inputTokens,
-          cachedInputTokens: usage.cachedInputTokens,
-          outputTokens: usage.outputTokens,
-          totalTokens: usage.totalTokens,
+      for (let toolIteration = 0; toolIteration < 4; toolIteration += 1) {
+        const input: ResponseInputItem[] = [...memory, ...turnItems];
+        const response = await this.client.responses.create({
+          model: this.config.openaiModel,
+          instructions,
+          input,
+          tools: botControlTools,
+          tool_choice: "required",
+          max_output_tokens: 512,
+          reasoning: { effort: "low", summary: "concise" },
+          include: ["reasoning.encrypted_content"],
+          store: false,
         });
-      } else {
-        this.logger.warn("openai.usage_missing");
-      }
 
-      this.logger.info("openai.raw_response", { text: response.output_text });
+        if (response.usage !== undefined) {
+          const usage = await this.usageStore.record(this.config.openaiModel, response.usage);
 
-      const reasoningSummary = extractReasoningSummary(response.output);
-      turnItems.push(...(stripReasoningSummaries(response.output) as ResponseInputItem[]));
+          this.logger.info("openai.usage", {
+            day: usage.day,
+            costUsd: usage.costUsd,
+            totalCostUsd: usage.totalCostUsd,
+            inputTokens: usage.inputTokens,
+            cachedInputTokens: usage.cachedInputTokens,
+            outputTokens: usage.outputTokens,
+            totalTokens: usage.totalTokens,
+          });
+        } else {
+          this.logger.warn("openai.usage_missing");
+        }
 
-      const toolCalls = response.output.filter(isBotControlToolCall);
+        this.logger.info("openai.raw_response", { text: response.output_text });
 
-      if (toolCalls.length !== 1) {
-        this.logger.warn("openai.invalid_tool_call_count", { count: toolCalls.length });
-        turnItems.push(
-          ...toolCalls.map((toolCall) =>
+        const reasoningSummary = extractReasoningSummary(response.output);
+        turnItems.push(...(stripReasoningSummaries(response.output) as ResponseInputItem[]));
+
+        const toolCalls = response.output.filter(isBotControlToolCall);
+
+        if (toolCalls.length !== 1) {
+          this.logger.warn("openai.invalid_tool_call_count", { count: toolCalls.length });
+          turnItems.push(
+            ...toolCalls.map((toolCall) =>
+              createFunctionCallOutput(toolCall, {
+                ok: false,
+                error: "expected exactly one tool call",
+              }),
+            ),
+          );
+          return {
+            type: "wait",
+            memoryItems: turnItems,
+          };
+        }
+
+        const toolCall = toolCalls[0];
+
+        if (toolCall === undefined) {
+          return {
+            type: "wait",
+            memoryItems: turnItems,
+          };
+        }
+
+        if (toolCall.name === "remember_person") {
+          const result = await executeRememberPersonTool(toolCall, toolExecutor, this.logger);
+          turnItems.push(createFunctionCallOutput(toolCall, result));
+          continue;
+        }
+
+        if (toolCall.name === "send_message") {
+          const action = parseMessageAction(toolCall);
+
+          if (action.channel.length > 0) {
+            const result = await executeSendChannelMessageTool(
+              toolCall,
+              action,
+              toolExecutor,
+              this.logger,
+            );
+            turnItems.push(createFunctionCallOutput(toolCall, result));
+            continue;
+          }
+
+          return createSendMessageResult(
+            toolCall,
+            action,
+            turnItems,
+            reasoningSummary,
+            response.output.length,
+            this.logger,
+          );
+        }
+
+        if (toolCall.name === "wait_for_more_messages") {
+          turnItems.push(
             createFunctionCallOutput(toolCall, {
-              ok: false,
-              error: "expected exactly one tool call",
+              ok: true,
+              paused_until: "new_human_message",
             }),
-          ),
-        );
-        return {
-          type: "wait",
-          memoryItems: turnItems,
-        };
-      }
+          );
+          this.logger.info("openai.response", {
+            action: "wait_command",
+            memoryItems: turnItems.length,
+          });
+          return {
+            type: "wait",
+            memoryItems: turnItems,
+          };
+        }
 
-      const toolCall = toolCalls[0];
-
-      if (toolCall === undefined) {
-        return {
-          type: "wait",
-          memoryItems: turnItems,
-        };
-      }
-
-      if (toolCall.name === "send_message") {
-        return createSendMessageResult(
+        return createSleepResult(
           toolCall,
           turnItems,
           reasoningSummary,
@@ -130,30 +187,11 @@ export class OpenAIResponder {
         );
       }
 
-      if (toolCall.name === "wait_for_more_messages") {
-        turnItems.push(
-          createFunctionCallOutput(toolCall, {
-            ok: true,
-            paused_until: "new_human_message",
-          }),
-        );
-        this.logger.info("openai.response", {
-          action: "wait_command",
-          memoryItems: turnItems.length,
-        });
-        return {
-          type: "wait",
-          memoryItems: turnItems,
-        };
-      }
-
-      return createSleepResult(
-        toolCall,
-        turnItems,
-        reasoningSummary,
-        response.output.length,
-        this.logger,
-      );
+      this.logger.warn("openai.tool_iteration_limit");
+      return {
+        type: "wait",
+        memoryItems: turnItems,
+      };
     } catch (error) {
       this.logger.warn("openai.failed", { error: String(error) });
       return { type: "failed", error };
@@ -162,6 +200,29 @@ export class OpenAIResponder {
 }
 
 const botControlTools = [
+  {
+    type: "function",
+    name: "remember_person",
+    description:
+      "Non-terminal action. Remember that a Discord username belongs to a real person when a human tells you or when it is clear from conversation. Use this before your final terminal action. The server will verify the username and reject duplicates.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        username: {
+          type: "string",
+          description:
+            "Discord username without @. Use the server username, not a display name, when possible.",
+        },
+        name: {
+          type: "string",
+          description: "The person's real name or preferred name.",
+        },
+      },
+      required: ["username", "name"],
+    },
+  },
   {
     type: "function",
     name: "send_message",
@@ -182,8 +243,13 @@ const botControlTools = [
           description:
             "Exactly one standard Unicode emoji to react with, or null when only sending a message.",
         },
+        channel: {
+          type: ["string", "null"],
+          description:
+            "Target channel for cross-channel messages, with or without a leading #, such as #general or general. Use null for the current channel.",
+        },
       },
-      required: ["text", "reaction"],
+      required: ["text", "reaction", "channel"],
     },
   },
   {
@@ -231,6 +297,7 @@ const botControlTools = [
 ] satisfies Tool[];
 
 type BotControlToolName =
+  | "remember_person"
   | "send_message"
   | "wait_for_more_messages"
   | "sleep_conversation";
@@ -244,9 +311,76 @@ function isBotControlToolCall(item: ResponseOutputItem): item is ResponseFunctio
 function isBotControlToolName(name: string): name is BotControlToolName {
   return (
     name === "send_message" ||
+    name === "remember_person" ||
     name === "wait_for_more_messages" ||
     name === "sleep_conversation"
   );
+}
+
+async function executeRememberPersonTool(
+  toolCall: ResponseFunctionToolCall,
+  toolExecutor: BotToolExecutor,
+  logger: Logger,
+): Promise<Record<string, unknown>> {
+  const input = parseRememberPersonAction(toolCall);
+
+  if (input.username.length === 0 || input.name.length === 0) {
+    logger.warn("openai.invalid_remember_person_args", {
+      usernameChars: input.username.length,
+      nameChars: input.name.length,
+    });
+    return {
+      ok: false,
+      error: "remember_person requires non-empty username and name",
+    };
+  }
+
+  const result = await toolExecutor.rememberPerson(input);
+  logger.info("openai.remember_person_result", result);
+
+  return result;
+}
+
+async function executeSendChannelMessageTool(
+  toolCall: ResponseFunctionToolCall,
+  action: MessageAction,
+  toolExecutor: BotToolExecutor,
+  logger: Logger,
+): Promise<Record<string, unknown>> {
+  if (action.text.length === 0) {
+    logger.warn("openai.empty_cross_channel_send_message", { channel: action.channel });
+    return {
+      ok: false,
+      error: "cross-channel send_message requires non-empty text",
+    };
+  }
+
+  if (action.reaction.length > 0) {
+    logger.warn("openai.invalid_cross_channel_send_message_reaction", {
+      channel: action.channel,
+      reaction: action.reaction,
+    });
+    return {
+      ok: false,
+      error: "cross-channel send_message cannot include a reaction",
+    };
+  }
+
+  const input: SendChannelMessageToolInput = {
+    channel: action.channel,
+    text: action.text,
+  };
+  const result = await toolExecutor.sendChannelMessage(input);
+  logger.info("openai.cross_channel_send_message_result", result);
+
+  if (result.ok) {
+    return {
+      ok: true,
+      channel: result.channel,
+    };
+  }
+
+  return result;
 }
 
 function parseFunctionArguments(args: string): Record<string, unknown> {
@@ -265,13 +399,12 @@ function parseFunctionArguments(args: string): Record<string, unknown> {
 
 function createSendMessageResult(
   toolCall: ResponseFunctionToolCall,
+  action: MessageAction,
   turnItems: ResponseInputItem[],
   reasoningSummary: string | undefined,
   outputItemCount: number,
   logger: Logger,
 ): ResponderResult {
-  const action = parseMessageAction(toolCall);
-
   if (action.reaction.length > 0 && !isSingleUnicodeEmoji(action.reaction)) {
     logger.warn("openai.invalid_send_message_reaction", { reaction: action.reaction });
     turnItems.push(
@@ -412,15 +545,20 @@ function createSleepResult(
   return result;
 }
 
-function parseMessageAction(toolCall: ResponseFunctionToolCall): {
+interface MessageAction {
   text: string;
   reaction: string;
-} {
+  channel: string;
+}
+
+function parseMessageAction(toolCall: ResponseFunctionToolCall): MessageAction {
   const args = parseFunctionArguments(toolCall.arguments);
+  const rawChannel = typeof args.channel === "string" ? args.channel.trim() : "";
 
   return {
     text: typeof args.text === "string" ? args.text.trim() : "",
     reaction: typeof args.reaction === "string" ? args.reaction.trim() : "",
+    channel: rawChannel.replace(/^#+/, "").trim(),
   };
 }
 
@@ -428,6 +566,19 @@ function parseSleepSummary(toolCall: ResponseFunctionToolCall): string {
   const args = parseFunctionArguments(toolCall.arguments);
 
   return typeof args.summary === "string" ? args.summary.trim() : "";
+}
+
+function parseRememberPersonAction(toolCall: ResponseFunctionToolCall): RememberPersonToolInput {
+  const args = parseFunctionArguments(toolCall.arguments);
+
+  return {
+    username: typeof args.username === "string" ? trimUsername(args.username) : "",
+    name: typeof args.name === "string" ? args.name.trim() : "",
+  };
+}
+
+function trimUsername(username: string): string {
+  return username.trim().replace(/^@+/, "");
 }
 
 function isSingleUnicodeEmoji(value: string): boolean {

--- a/src/openai/types.ts
+++ b/src/openai/types.ts
@@ -2,6 +2,43 @@ import type { ResponseInputItem } from "openai/resources/responses/responses";
 
 export type ApiMemory = ResponseInputItem[];
 
+export interface RememberPersonToolInput {
+  username: string;
+  name: string;
+}
+
+export type RememberPersonToolResult =
+  | {
+      ok: true;
+      username: string;
+      name: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export interface SendChannelMessageToolInput {
+  channel: string;
+  text: string;
+}
+
+export type SendChannelMessageToolResult =
+  | {
+      ok: true;
+      channel: string;
+      channelId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export interface BotToolExecutor {
+  rememberPerson(input: RememberPersonToolInput): Promise<RememberPersonToolResult>;
+  sendChannelMessage(input: SendChannelMessageToolInput): Promise<SendChannelMessageToolResult>;
+}
+
 export type ResponderResult =
   | {
       type: "message";

--- a/src/prompts/system.txt
+++ b/src/prompts/system.txt
@@ -12,17 +12,25 @@ You are not a real person though, so don't pretend you can do things that you ca
 
 There will be multiple people in a conversation so you need to try to figure out the conversations that are going on and address people when possible. Messages will come in with prefixes of who's typing what. Your responses don't need a prefix.
 
+If you don't know someone's real or preferred name and it would help make the conversation more natural, ask them what name you should use. Don't force it if it would interrupt the flow.
+
 When you need to directly grab someones attention, you can ping them by writing @username, like @makandz. Do not write raw Discord mention IDs like <@123>, and do not wrap username pings in angle brackets like <@makandz>. Usually just responding is okay but if you're addressing messages to different people you might want to ping them.
+
+When referring to a Discord channel, write it as #channel-name, like #general. Do not write raw Discord channel IDs like <#123>.
 
 ## Tool access:
 
-For normal replies, call send_message with text set to the message and reaction set to null. Do not put user-visible Discord replies in plain assistant text.
+For normal replies in the current channel, call send_message with text set to the message, reaction set to null, and channel set to null. Do not put user-visible Discord replies in plain assistant text.
 
-send_message is a terminal action: after the message and/or reaction is sent, execution pauses until new human messages arrive.
+send_message with channel set to null is a terminal action: after the message and/or reaction is sent, execution pauses until new human messages arrive.
+
+If someone asks you to send a message in a different Discord channel, call send_message with text set to the message, reaction set to null, and channel set to the target channel name with or without #, like "general" or "#general". Cross-channel send_message is not terminal: after it succeeds or fails, continue with send_message for the current channel, wait_for_more_messages, or sleep_conversation. Do not use channel for the current channel.
+
+When someone clearly tells you a Discord username belongs to a real person, call remember_person with that username and name before your final terminal action. remember_person is not terminal: after it succeeds or fails, continue with send_message, wait_for_more_messages, or sleep_conversation. Do not announce the remember_person result yourself because the server will post a status message.
 
 Sometimes there may be multiple conversations going on and you might be waiting for a reply. If you don't want to send a message but still need to remain part of the conversation, call wait_for_more_messages and you'll get the follow-up messages afterwards. wait_for_more_messages is also a terminal action, and execution pauses until new human messages arrive.
 
-If a lightweight acknowledgement is better than a message, call send_message with text set to null and reaction set to exactly one standard Unicode emoji. Use this for things like acknowledging, agreeing, laughing, thanking, or showing that you saw something. Do not use Discord custom emoji names, text aliases, words, or multiple emojis. Make SURE you prioritize reacting over sending messages when possible.
+If a lightweight acknowledgement is better than a message, call send_message with text set to null, reaction set to exactly one standard Unicode emoji, and channel set to null. Use this for things like acknowledging, agreeing, laughing, thanking, or showing that you saw something. Do not use Discord custom emoji names, text aliases, words, or multiple emojis. Make SURE you prioritize reacting over sending messages when possible.
 
 If at any point you're no longer needed in the conversation (i.e. other people are talking to each other, your purpose has been fullfilled), call sleep_conversation and you'll go back to sleep. sleep_conversation is a terminal action. You must include a factual 1-2 sentence summary of the conversation you just had. You may optionally set text to a short final message and/or reaction to exactly one standard Unicode emoji to send before sleeping. Use null for either one when not needed.
 


### PR DESCRIPTION
- Ben can remember Discord users’ real or preferred names during conversation.
- Remembered people are validated against the server before being stored.
- Ben can send requested messages to another Discord channel by name, like `#general`.
- Discord channel mentions are handled as readable `#channel-name` text in conversation context.
- Ben stays active in one channel at a time and queues pings from other channels until the current conversation sleeps.
- Cross-channel message failures and remembered-name updates are surfaced back in Discord.
- Ben can ask for someone’s preferred name when it would make the conversation more natural.
- Bot runtime configuration is expanded for model selection, state paths, known people storage, logging, and timing defaults.