### PR TITLE
Add scheduled Discord messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ TypeScript Discord bot that wakes on a ping, batches recent human messages, and 
 
 The bot logs when it connects. It replies in the channel where the triggering message batch was received, and can route requested messages to another server channel by name. Ben stays active in one channel at a time; pings from other channels are queued until the current channel sleeps. Status messages such as wake, wait, sleep, and reasoning summaries are sent to `DISCORD_LOG_CHANNEL_ID` when configured.
 
+## Scheduled Messages
+
+Ben can schedule future messages from natural Discord requests, such as:
+
+```text
+ben remind me tomorrow at 9 to check the deploy
+ben every day at 6pm ask alex and priya if they're joining the call tonight
+```
+
+Scheduled messages require real target users. Ben validates usernames and channels before saving, stores resolved Discord user IDs and channel IDs, and persists schedules to JSON so they survive restarts. At send time, Ben posts the target user pings followed by the scheduled text.
+
+Supported repeats are one-time, daily, and weekly. Monthly schedules are intentionally not supported yet. Dates and times are interpreted in the configured bot timezone.
+
 ## Internal Actions
 
 The bot can run separate scheduled internal actions using their own prompt files under `src/prompts/internal/`.
@@ -62,6 +75,9 @@ The last status is stored in a separate JSON file at `logs/internal-state.json` 
 - `OPENAI_USAGE_LOG_DIR` defaults to `logs/openai-usage`. Usage is stored in monthly `YYMM.json` files with daily buckets.
 - `BOT_INTERNAL_STATE_PATH` defaults to `logs/internal-state.json`. Internal action state is stored separately from usage.
 - `BOT_KNOWN_PEOPLE_PATH` defaults to `logs/known-people.json`. The bot stores remembered Discord users and names there after validating them against the server.
+- `BOT_SCHEDULED_MESSAGES_PATH` defaults to `logs/scheduled-messages.json`. Scheduled messages are stored there.
+- `BOT_SCHEDULE_TIMEZONE` defaults to `America/Toronto`. Scheduled message dates and times are interpreted in this timezone.
+- `BOT_SCHEDULE_CHECK_INTERVAL_MS` defaults to `30000`. The scheduler checks for due messages on this interval.
 - `DISCORD_LOG_CHANNEL_ID` optionally enables internal action log lines, wake/wait/sleep status messages, and reasoning summaries in a dedicated Discord channel.
 - `LOG_LEVEL` defaults to `info`; use `debug` for queue and debounce details.
 - `LOG_PROMPTS=true` logs full prompts at debug level.

--- a/src/bot/BotSession.ts
+++ b/src/bot/BotSession.ts
@@ -8,10 +8,13 @@ import type {
   ResponderResult,
   SendChannelMessageToolInput,
   SendChannelMessageToolResult,
+  CreateScheduledMessageToolInput,
+  CreateScheduledMessageToolResult,
 } from "../openai/types.js";
 import type { ConversationSummaryStore } from "./conversationSummaryStore.js";
 import { buildUserPrompt } from "./formatMessages.js";
 import type { KnownPeopleStore } from "./knownPeopleStore.js";
+import { formatBotTime } from "./scheduleTime.js";
 import type { BotMode, HumanMessage } from "./types.js";
 
 type SendMessageToChannel = (channelId: string, text: string) => Promise<void>;
@@ -28,6 +31,11 @@ type SendChannelMessage = (
   input: SendChannelMessageToolInput,
   activeChannelId: string | undefined,
 ) => Promise<SendChannelMessageToolResult>;
+type CreateScheduledMessage = (
+  input: CreateScheduledMessageToolInput,
+  activeChannelId: string | undefined,
+  createdBy: HumanMessage | undefined,
+) => Promise<CreateScheduledMessageToolResult>;
 
 interface TypingActivity {
   expiresAt: number;
@@ -66,6 +74,7 @@ export class BotSession {
     private readonly knownPeopleStore: KnownPeopleStore,
     private readonly rememberPerson: RememberPerson,
     private readonly sendChannelMessage: SendChannelMessage,
+    private readonly createScheduledMessage: CreateScheduledMessage,
     private readonly logger: Logger,
   ) {}
 
@@ -374,6 +383,7 @@ export class BotSession {
       knownPeople,
       includeKnownPeople: includeFirstPromptContext,
       recentConversationSummaries,
+      currentBotTime: formatBotTime(new Date(), this.config.scheduleTimezone),
     };
 
     if (currentActivityStatus !== undefined) {
@@ -412,6 +422,8 @@ export class BotSession {
 
           return result;
         },
+        createScheduledMessage: (input) =>
+          this.createScheduledMessage(input, responseChannelId, messages[0]),
       });
       await this.handleResponderResult(result, responseChannelId, reactionTargetMessageId);
     } finally {

--- a/src/bot/formatMessages.ts
+++ b/src/bot/formatMessages.ts
@@ -45,6 +45,7 @@ export function buildUserPrompt(options: {
   knownPeople?: KnownPeople;
   includeKnownPeople?: boolean;
   currentActivityStatus?: string;
+  currentBotTime?: string;
   pingedByUsername?: string;
   recentConversationSummaries?: readonly ConversationSummary[];
 }): string {
@@ -61,6 +62,12 @@ export function buildUserPrompt(options: {
 
   if (options.currentActivityStatus !== undefined) {
     sections.push(`Ben's current activity status is "${options.currentActivityStatus}".`);
+  }
+
+  if (options.currentBotTime !== undefined) {
+    sections.push(
+      `Current bot time: ${options.currentBotTime}. Scheduled message tool dates must be YYYY-MM-DD and times must be 24-hour HH:mm in the bot's local time.`,
+    );
   }
 
   if (options.pingedByUsername !== undefined) {

--- a/src/bot/scheduleTime.ts
+++ b/src/bot/scheduleTime.ts
@@ -1,0 +1,197 @@
+export type ScheduleRepeat = "none" | "daily" | "weekly";
+
+export interface ScheduledLocalTime {
+  runDate: string;
+  runTime: string;
+  timeZone: string;
+}
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const timePattern = /^\d{2}:\d{2}$/;
+
+export function validateRunDate(runDate: string): boolean {
+  if (!datePattern.test(runDate)) {
+    return false;
+  }
+
+  const [year, month, day] = runDate.split("-").map(Number);
+
+  if (year === undefined || month === undefined || day === undefined) {
+    return false;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+export function validateRunTime(runTime: string): boolean {
+  if (!timePattern.test(runTime)) {
+    return false;
+  }
+
+  const [hour, minute] = runTime.split(":").map(Number);
+
+  return (
+    hour !== undefined &&
+    minute !== undefined &&
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59
+  );
+}
+
+export function localScheduleToDate(input: ScheduledLocalTime): Date {
+  if (!validateRunDate(input.runDate)) {
+    throw new Error("run_date must be YYYY-MM-DD.");
+  }
+
+  if (!validateRunTime(input.runTime)) {
+    throw new Error("run_time must be HH:mm.");
+  }
+
+  const [year, month, day] = input.runDate.split("-").map(Number);
+  const [hour, minute] = input.runTime.split(":").map(Number);
+
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined ||
+    minute === undefined
+  ) {
+    throw new Error("Invalid local schedule.");
+  }
+
+  const localAsUtc = Date.UTC(year, month - 1, day, hour, minute);
+  const guessedInstant = new Date(localAsUtc);
+  const offsetMs = getTimeZoneOffsetMs(guessedInstant, input.timeZone);
+  const instant = new Date(localAsUtc - offsetMs);
+  const actual = getTimeZoneParts(instant, input.timeZone);
+
+  if (
+    actual.year !== year ||
+    actual.month !== month ||
+    actual.day !== day ||
+    actual.hour !== hour ||
+    actual.minute !== minute
+  ) {
+    throw new Error("run_date and run_time do not exist in the configured timezone.");
+  }
+
+  return instant;
+}
+
+export function computeNextRunAt(
+  lastRunAt: Date,
+  repeat: ScheduleRepeat,
+  timeZone: string,
+): Date | undefined {
+  if (repeat === "none") {
+    return undefined;
+  }
+
+  const parts = getTimeZoneParts(lastRunAt, timeZone);
+  const nextLocalDate =
+    repeat === "daily"
+      ? addDays(parts.year, parts.month, parts.day, 1)
+      : addDays(parts.year, parts.month, parts.day, 7);
+
+  return localScheduleToDate({
+    runDate: formatDate(nextLocalDate.year, nextLocalDate.month, nextLocalDate.day),
+    runTime: formatTime(parts.hour, parts.minute),
+    timeZone,
+  });
+}
+
+export function formatBotTime(now: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(now);
+}
+
+function getTimeZoneOffsetMs(instant: Date, timeZone: string): number {
+  const parts = getTimeZoneParts(instant, timeZone);
+  const localAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
+
+  return localAsUtc - instant.getTime();
+}
+
+function getTimeZoneParts(
+  instant: Date,
+  timeZone: string,
+): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+} {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = formatter.formatToParts(instant);
+
+  return {
+    year: requirePart(parts, "year"),
+    month: requirePart(parts, "month"),
+    day: requirePart(parts, "day"),
+    hour: requirePart(parts, "hour"),
+    minute: requirePart(parts, "minute"),
+  };
+}
+
+function requirePart(parts: Intl.DateTimeFormatPart[], type: string): number {
+  const value = parts.find((part) => part.type === type)?.value;
+
+  if (value === undefined) {
+    throw new Error(`Missing ${type} from timezone formatter.`);
+  }
+
+  return Number(value);
+}
+
+function addDays(
+  year: number,
+  month: number,
+  day: number,
+  days: number,
+): {
+  year: number;
+  month: number;
+  day: number;
+} {
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+function formatDate(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function formatTime(hour: number, minute: number): string {
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}

--- a/src/bot/scheduledMessageScheduler.ts
+++ b/src/bot/scheduledMessageScheduler.ts
@@ -1,0 +1,158 @@
+import type { AppConfig } from "../config.js";
+import type { Logger } from "../logger.js";
+import { computeNextRunAt } from "./scheduleTime.js";
+import type { ScheduledMessage, ScheduledMessageStore } from "./scheduledMessageStore.js";
+
+type SendScheduledMessage = (message: ScheduledMessage) => Promise<void>;
+type SendLogMessage = (text: string) => Promise<boolean>;
+
+export class ScheduledMessageScheduler {
+  private timer: NodeJS.Timeout | undefined;
+  private running = false;
+  private startedAt: Date | undefined;
+
+  constructor(
+    private readonly config: AppConfig,
+    private readonly store: ScheduledMessageStore,
+    private readonly sendScheduledMessage: SendScheduledMessage,
+    private readonly sendLogMessage: SendLogMessage,
+    private readonly logger: Logger,
+  ) {}
+
+  start(): void {
+    this.startedAt = new Date();
+    void this.runDueMessages("startup");
+    this.timer = setInterval(() => {
+      void this.runDueMessages("interval");
+    }, this.config.scheduleCheckIntervalMs);
+
+    this.logger.info("scheduled_messages.scheduler_started", {
+      intervalMs: this.config.scheduleCheckIntervalMs,
+      timeZone: this.config.scheduleTimezone,
+    });
+  }
+
+  stop(): void {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async runDueMessages(reason: string): Promise<void> {
+    if (this.running) {
+      this.logger.debug("scheduled_messages.skipped_running", { reason });
+      return;
+    }
+
+    this.running = true;
+
+    try {
+      const now = new Date();
+      const dueMessages = await this.store.listDue(now);
+
+      for (const message of dueMessages) {
+        await this.runDueMessage(message, now, reason);
+      }
+    } catch (error) {
+      this.logger.warn("scheduled_messages.tick_failed", { reason, error: String(error) });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runDueMessage(
+    message: ScheduledMessage,
+    now: Date,
+    reason: string,
+  ): Promise<void> {
+    const dueAt = new Date(message.nextRunAt);
+
+    if (message.repeat !== "none" && this.wasMissedBeforeStartup(dueAt)) {
+      const nextRunAt = computeNextFutureRunAt(dueAt, message.repeat, this.config.scheduleTimezone, now);
+
+      await this.store.reschedule(message.id, nextRunAt, now);
+      await this.writeLogLine(
+        `Skipped missed scheduled message ${message.id}; next run is ${nextRunAt.toISOString()}`,
+      );
+      this.logger.info("scheduled_messages.skipped_missed_recurring", {
+        id: message.id,
+        reason,
+        dueAt: message.nextRunAt,
+        nextRunAt: nextRunAt.toISOString(),
+      });
+      return;
+    }
+
+    try {
+      await this.sendScheduledMessage(message);
+
+      const nextRunAt = computeNextRunAt(dueAt, message.repeat, this.config.scheduleTimezone);
+      await this.store.markSent(message.id, nextRunAt, now);
+      await this.writeLogLine(formatSentLogLine(message, nextRunAt));
+      this.logger.info("scheduled_messages.sent", {
+        id: message.id,
+        repeat: message.repeat,
+        channelId: message.channelId,
+        targetUsers: message.targetUsers.length,
+        nextRunAt: nextRunAt?.toISOString(),
+      });
+    } catch (error) {
+      const failureCount = await this.store.markFailed(message.id, now);
+
+      await this.writeLogLine(
+        `Failed to send scheduled message ${message.id}: ${String(error)}`,
+      );
+      this.logger.warn("scheduled_messages.send_failed", {
+        id: message.id,
+        failureCount,
+        error: String(error),
+      });
+    }
+  }
+
+  private wasMissedBeforeStartup(dueAt: Date): boolean {
+    return this.startedAt !== undefined && dueAt.getTime() < this.startedAt.getTime();
+  }
+
+  private async writeLogLine(text: string): Promise<void> {
+    await this.sendLogMessage(text).catch((error: unknown) => {
+      this.logger.warn("scheduled_messages.log_failed", { error: String(error) });
+    });
+  }
+}
+
+function computeNextFutureRunAt(
+  dueAt: Date,
+  repeat: "daily" | "weekly",
+  timeZone: string,
+  now: Date,
+): Date {
+  let nextRunAt = computeNextRunAt(dueAt, repeat, timeZone);
+
+  while (nextRunAt !== undefined && nextRunAt.getTime() <= now.getTime()) {
+    nextRunAt = computeNextRunAt(nextRunAt, repeat, timeZone);
+  }
+
+  if (nextRunAt === undefined) {
+    throw new Error("Recurring scheduled message did not produce a next run.");
+  }
+
+  return nextRunAt;
+}
+
+function formatSentLogLine(
+  message: ScheduledMessage,
+  nextRunAt: Date | undefined,
+): string {
+  const targetText =
+    message.targetUsers.length === 0
+      ? "no targets"
+      : message.targetUsers.map((target) => `@${target.username}`).join(", ");
+
+  if (nextRunAt === undefined) {
+    return `Sent scheduled message ${message.id} to #${message.channelName} (${targetText}); schedule complete.`;
+  }
+
+  return `Sent scheduled message ${message.id} to #${message.channelName} (${targetText}); next run is ${nextRunAt.toISOString()}.`;
+}

--- a/src/bot/scheduledMessageStore.ts
+++ b/src/bot/scheduledMessageStore.ts
@@ -1,0 +1,286 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { Logger } from "../logger.js";
+import type { ScheduleRepeat } from "./scheduleTime.js";
+
+export interface ScheduledMessageTarget {
+  userId: string;
+  username: string;
+}
+
+export interface ScheduledMessage {
+  id: string;
+  channelId: string;
+  channelName: string;
+  message: string;
+  targetUsers: ScheduledMessageTarget[];
+  runDate: string;
+  runTime: string;
+  repeat: ScheduleRepeat;
+  nextRunAt: string;
+  enabled: boolean;
+  createdByUserId: string;
+  createdByUsername: string;
+  createdAt: string;
+  updatedAt: string;
+  lastRunAt?: string;
+  failureCount?: number;
+}
+
+export interface CreateScheduledMessageInput {
+  channelId: string;
+  channelName: string;
+  message: string;
+  targetUsers: ScheduledMessageTarget[];
+  runDate: string;
+  runTime: string;
+  repeat: ScheduleRepeat;
+  nextRunAt: Date;
+  createdByUserId: string;
+  createdByUsername: string;
+}
+
+interface ScheduledMessagesData {
+  version: number;
+  messages: ScheduledMessage[];
+}
+
+export class ScheduledMessageStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly logger: Logger,
+  ) {}
+
+  async add(input: CreateScheduledMessageInput, now = new Date()): Promise<ScheduledMessage> {
+    const data = await this.read();
+    const timestamp = now.toISOString();
+    const message: ScheduledMessage = {
+      id: `sm_${randomUUID().slice(0, 8)}`,
+      channelId: input.channelId,
+      channelName: input.channelName,
+      message: input.message,
+      targetUsers: input.targetUsers,
+      runDate: input.runDate,
+      runTime: input.runTime,
+      repeat: input.repeat,
+      nextRunAt: input.nextRunAt.toISOString(),
+      enabled: true,
+      createdByUserId: input.createdByUserId,
+      createdByUsername: input.createdByUsername,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    data.messages.push(message);
+    await this.write(data);
+
+    return message;
+  }
+
+  async listDue(now = new Date()): Promise<ScheduledMessage[]> {
+    const data = await this.read();
+
+    return data.messages.filter(
+      (message) => message.enabled && Date.parse(message.nextRunAt) <= now.getTime(),
+    );
+  }
+
+  async markSent(id: string, nextRunAt: Date | undefined, now = new Date()): Promise<void> {
+    const data = await this.read();
+    const message = data.messages.find((item) => item.id === id);
+
+    if (message === undefined) {
+      return;
+    }
+
+    message.lastRunAt = now.toISOString();
+    message.updatedAt = now.toISOString();
+    message.failureCount = 0;
+
+    if (nextRunAt === undefined) {
+      message.enabled = false;
+    } else {
+      message.nextRunAt = nextRunAt.toISOString();
+    }
+
+    await this.write(data);
+  }
+
+  async reschedule(id: string, nextRunAt: Date, now = new Date()): Promise<void> {
+    const data = await this.read();
+    const message = data.messages.find((item) => item.id === id);
+
+    if (message === undefined) {
+      return;
+    }
+
+    message.nextRunAt = nextRunAt.toISOString();
+    message.updatedAt = now.toISOString();
+    await this.write(data);
+  }
+
+  async markFailed(id: string, now = new Date()): Promise<number> {
+    const data = await this.read();
+    const message = data.messages.find((item) => item.id === id);
+
+    if (message === undefined) {
+      return 0;
+    }
+
+    message.failureCount = (message.failureCount ?? 0) + 1;
+    message.updatedAt = now.toISOString();
+    await this.write(data);
+
+    return message.failureCount;
+  }
+
+  private async read(): Promise<ScheduledMessagesData> {
+    let raw: string;
+
+    try {
+      raw = await readFile(this.filePath, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return { version: 1, messages: [] };
+      }
+
+      throw error;
+    }
+
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(`${this.filePath} must contain valid JSON.`);
+    }
+
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error(`${this.filePath} must contain a JSON object.`);
+    }
+
+    const messages = (parsed as { messages?: unknown }).messages;
+
+    if (!Array.isArray(messages)) {
+      return { version: 1, messages: [] };
+    }
+
+    return {
+      version: 1,
+      messages: messages
+        .map((message) => parseScheduledMessage(message, this.logger))
+        .filter((message): message is ScheduledMessage => message !== undefined),
+    };
+  }
+
+  private async write(data: ScheduledMessagesData): Promise<void> {
+    const dir = path.dirname(this.filePath);
+
+    await mkdir(dir, { recursive: true });
+
+    const tempPath = path.join(
+      dir,
+      `.${path.basename(this.filePath)}.${String(process.pid)}.${String(Date.now())}.tmp`,
+    );
+
+    await writeFile(tempPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    await rename(tempPath, this.filePath);
+  }
+}
+
+function parseScheduledMessage(
+  value: unknown,
+  logger: Logger,
+): ScheduledMessage | undefined {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    logger.warn("scheduled_messages.invalid_entry_ignored");
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const targetUsers = parseTargetUsers(record.targetUsers);
+
+  if (
+    typeof record.id !== "string" ||
+    typeof record.channelId !== "string" ||
+    typeof record.channelName !== "string" ||
+    typeof record.message !== "string" ||
+    targetUsers === undefined ||
+    typeof record.runDate !== "string" ||
+    typeof record.runTime !== "string" ||
+    !isScheduleRepeat(record.repeat) ||
+    typeof record.nextRunAt !== "string" ||
+    typeof record.enabled !== "boolean" ||
+    typeof record.createdByUserId !== "string" ||
+    typeof record.createdByUsername !== "string" ||
+    typeof record.createdAt !== "string" ||
+    typeof record.updatedAt !== "string"
+  ) {
+    logger.warn("scheduled_messages.invalid_entry_ignored");
+    return undefined;
+  }
+
+  const message: ScheduledMessage = {
+    id: record.id,
+    channelId: record.channelId,
+    channelName: record.channelName,
+    message: record.message,
+    targetUsers,
+    runDate: record.runDate,
+    runTime: record.runTime,
+    repeat: record.repeat,
+    nextRunAt: record.nextRunAt,
+    enabled: record.enabled,
+    createdByUserId: record.createdByUserId,
+    createdByUsername: record.createdByUsername,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+
+  if (typeof record.lastRunAt === "string") {
+    message.lastRunAt = record.lastRunAt;
+  }
+
+  if (typeof record.failureCount === "number") {
+    message.failureCount = record.failureCount;
+  }
+
+  return message;
+}
+
+function parseTargetUsers(value: unknown): ScheduledMessageTarget[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const targets: ScheduledMessageTarget[] = [];
+
+  for (const item of value) {
+    if (item === null || Array.isArray(item) || typeof item !== "object") {
+      return undefined;
+    }
+
+    const record = item as Record<string, unknown>;
+
+    if (typeof record.userId !== "string" || typeof record.username !== "string") {
+      return undefined;
+    }
+
+    targets.push({
+      userId: record.userId,
+      username: record.username,
+    });
+  }
+
+  return targets;
+}
+
+function isScheduleRepeat(value: unknown): value is ScheduleRepeat {
+  return value === "none" || value === "daily" || value === "weekly";
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface AppConfig {
   internalStatePath: string;
   conversationSummaryPath: string;
   knownPeoplePath: string;
+  scheduledMessagesPath: string;
   discordLogChannelId: string | undefined;
   logLevel: LogLevel;
   logPrompts: boolean;
@@ -21,6 +22,8 @@ export interface AppConfig {
   typingDebounceMs: number;
   idleSleepMs: number;
   internalActionIntervalMs: number;
+  scheduleCheckIntervalMs: number;
+  scheduleTimezone: string;
 }
 
 const logLevels = new Set<LogLevel>(["debug", "info", "warn", "error"]);
@@ -74,6 +77,8 @@ export function loadConfig(): AppConfig {
     conversationSummaryPath:
       process.env.BOT_CONVERSATION_SUMMARY_PATH ?? "logs/conversation-summaries.json",
     knownPeoplePath: process.env.BOT_KNOWN_PEOPLE_PATH ?? "logs/known-people.json",
+    scheduledMessagesPath:
+      process.env.BOT_SCHEDULED_MESSAGES_PATH ?? "logs/scheduled-messages.json",
     discordLogChannelId: process.env.DISCORD_LOG_CHANNEL_ID,
     logLevel: readLogLevel(),
     logPrompts: process.env.LOG_PROMPTS === "true",
@@ -84,5 +89,7 @@ export function loadConfig(): AppConfig {
       "BOT_INTERNAL_ACTION_INTERVAL_MS",
       24 * 60 * 60 * 1_000,
     ),
+    scheduleCheckIntervalMs: readNumberEnv("BOT_SCHEDULE_CHECK_INTERVAL_MS", 30_000),
+    scheduleTimezone: process.env.BOT_SCHEDULE_TIMEZONE ?? "America/Toronto",
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,13 @@ import { Events, type Guild, type GuildMember, type NonThreadGuildBasedChannel }
 import { BotSession } from "./bot/BotSession.js";
 import { ConversationSummaryStore } from "./bot/conversationSummaryStore.js";
 import { KnownPeopleStore } from "./bot/knownPeopleStore.js";
+import { localScheduleToDate } from "./bot/scheduleTime.js";
+import { ScheduledMessageScheduler } from "./bot/scheduledMessageScheduler.js";
+import {
+  ScheduledMessageStore,
+  type ScheduledMessage,
+  type ScheduledMessageTarget,
+} from "./bot/scheduledMessageStore.js";
 import { loadConfig } from "./config.js";
 import { createDiscordClient } from "./discord/client.js";
 import { isPing, toHumanMessage } from "./discord/message.js";
@@ -20,6 +27,8 @@ import { InternalStateStore } from "./internal/stateStore.js";
 import { Logger } from "./logger.js";
 import { OpenAIResponder } from "./openai/responder.js";
 import type {
+  CreateScheduledMessageToolInput,
+  CreateScheduledMessageToolResult,
   RememberPersonToolInput,
   RememberPersonToolResult,
   SendChannelMessageToolInput,
@@ -36,6 +45,7 @@ const conversationSummaryStore = new ConversationSummaryStore(
   logger,
 );
 const knownPeopleStore = new KnownPeopleStore(config.knownPeoplePath, logger);
+const scheduledMessageStore = new ScheduledMessageStore(config.scheduledMessagesPath, logger);
 const responder = new OpenAIResponder(config, logger, usageStore);
 const internalActionRunner = new InternalActionRunner(config, logger, usageStore);
 const internalStateStore = new InternalStateStore(config.internalStatePath, logger);
@@ -69,6 +79,13 @@ const internalActionScheduler = new InternalActionScheduler(
   async (text) => {
     await sendLogMessage(text);
   },
+  logger,
+);
+const scheduledMessageScheduler = new ScheduledMessageScheduler(
+  config,
+  scheduledMessageStore,
+  sendScheduledDiscordMessage,
+  sendLogMessage,
   logger,
 );
 
@@ -123,6 +140,7 @@ const session = new BotSession(
   knownPeopleStore,
   rememberPersonInChannel,
   sendMessageToNamedChannel,
+  createScheduledMessageInChannel,
   logger,
 );
 
@@ -131,6 +149,7 @@ client.once(Events.ClientReady, (readyClient) => {
   logger.info("discord.ready", { user: readyClient.user.tag });
   internalActionScheduler.setAwakePresence(false);
   internalActionScheduler.start();
+  scheduledMessageScheduler.start();
   void registerUsageCommand(readyClient, logger).catch((error: unknown) => {
     logger.warn("discord.command_registration_failed", { error: String(error) });
   });
@@ -172,11 +191,13 @@ client.on(Events.Error, (error) => {
 
 process.once("SIGINT", () => {
   internalActionScheduler.stop();
+  scheduledMessageScheduler.stop();
   void client.destroy();
 });
 
 process.once("SIGTERM", () => {
   internalActionScheduler.stop();
+  scheduledMessageScheduler.stop();
   void client.destroy();
 });
 
@@ -257,6 +278,121 @@ async function sendMessageToNamedChannel(
   }
 }
 
+async function sendScheduledDiscordMessage(message: ScheduledMessage): Promise<void> {
+  const pings = message.targetUsers.map((target) => `<@${target.userId}>`).join(" ");
+  const content = `${pings} ${message.message}`.trim();
+
+  await sendDiscordMessage(message.channelId, content);
+}
+
+async function createScheduledMessageInChannel(
+  input: CreateScheduledMessageToolInput,
+  activeChannelId: string | undefined,
+  createdBy: { userId: string; username: string } | undefined,
+): Promise<CreateScheduledMessageToolResult> {
+  const messageText = sanitizeScheduledMessageText(input.message);
+  const channelName = input.channel === null ? "" : sanitizeChannelName(input.channel);
+  const fail = async (error: string): Promise<CreateScheduledMessageToolResult> => {
+    await sendRememberStatus(`> ⚠️ Failed to schedule message: ${error}`, activeChannelId);
+    return { ok: false, error };
+  };
+
+  if (messageText.length === 0 || messageText.length > 1_000) {
+    return fail("message must be 1-1000 characters");
+  }
+
+  if (input.targetUsernames.length === 0) {
+    return fail("at least one real user must be targeted");
+  }
+
+  if (activeChannelId === undefined) {
+    return fail("no active Discord channel");
+  }
+
+  if (createdBy === undefined) {
+    return fail("missing creator");
+  }
+
+  let firstRunAt: Date;
+
+  try {
+    firstRunAt = localScheduleToDate({
+      runDate: input.runDate,
+      runTime: input.runTime,
+      timeZone: config.scheduleTimezone,
+    });
+  } catch (error) {
+    return fail(String(error));
+  }
+
+  if (firstRunAt.getTime() <= Date.now()) {
+    return fail("run_date and run_time must be in the future");
+  }
+
+  try {
+    const activeChannel = await client.channels.fetch(activeChannelId);
+
+    if (activeChannel === null || !("guild" in activeChannel)) {
+      return await fail("active channel is not in a server");
+    }
+
+    const targetChannel =
+      channelName.length === 0
+        ? activeChannel
+        : await findMatchingGuildChannel(activeChannel.guild, channelName);
+
+    if (!targetChannel?.isSendable()) {
+      return await fail("target channel is not sendable or could not be found");
+    }
+
+    channelDirectory.rememberChannel(targetChannel);
+
+    const targetUsers = await resolveScheduledMessageTargets(
+      activeChannel.guild,
+      input.targetUsernames,
+    );
+
+    if (targetUsers.length === 0) {
+      return await fail("at least one real user must be targeted");
+    }
+
+    const scheduledMessage = await scheduledMessageStore.add({
+      channelId: targetChannel.id,
+      channelName: targetChannel.name,
+      message: messageText,
+      targetUsers,
+      runDate: input.runDate,
+      runTime: input.runTime,
+      repeat: input.repeat,
+      nextRunAt: firstRunAt,
+      createdByUserId: createdBy.userId,
+      createdByUsername: createdBy.username,
+    });
+
+    await sendRememberStatus(
+      formatScheduledMessageCreatedStatus(scheduledMessage),
+      activeChannelId,
+    );
+
+    await sendLogMessage(
+      `Created scheduled message ${scheduledMessage.id} for #${scheduledMessage.channelName} at ${scheduledMessage.nextRunAt} (${scheduledMessage.repeat}).`,
+    ).catch((error: unknown) => {
+      logger.warn("scheduled_messages.create_log_failed", { error: String(error) });
+    });
+
+    return {
+      ok: true,
+      id: scheduledMessage.id,
+      nextRunAt: scheduledMessage.nextRunAt,
+      repeat: scheduledMessage.repeat,
+      channel: scheduledMessage.channelName,
+      targetUsernames: scheduledMessage.targetUsers.map((target) => target.username),
+    };
+  } catch (error) {
+    return fail(String(error));
+  }
+}
+
 async function sendChannelMessageFailureStatus(
   channelName: string,
   error: string,
@@ -273,6 +409,52 @@ async function sendChannelMessageFailureStatus(
     `> ⚠️ Failed to send message to #${channelName}: ${error}`,
     activeChannelId,
   );
+}
+
+async function resolveScheduledMessageTargets(
+  guild: Guild,
+  usernames: readonly string[],
+): Promise<ScheduledMessageTarget[]> {
+  const targets: ScheduledMessageTarget[] = [];
+  const seenUserIds = new Set<string>();
+
+  for (const rawUsername of usernames) {
+    const username = sanitizeRememberText(rawUsername).replace(/^@+/, "");
+    const normalizedUsername = username.toLowerCase();
+
+    if (
+      normalizedUsername.length === 0 ||
+      normalizedUsername === "everyone" ||
+      normalizedUsername === "here"
+    ) {
+      throw new Error("target usernames must be real Discord users");
+    }
+
+    const members = await guild.members.search({
+      query: username,
+      limit: 10,
+      cache: true,
+    });
+    const member = findMatchingMember(username, [...members.values()]);
+
+    if (member === undefined) {
+      throw new Error(`no matching server member found for "${username}"`);
+    }
+
+    if (seenUserIds.has(member.id)) {
+      continue;
+    }
+
+    mentionDirectory.rememberUser(member.user);
+    mentionDirectory.rememberUsername(username, member.id);
+    seenUserIds.add(member.id);
+    targets.push({
+      userId: member.id,
+      username: member.user.username,
+    });
+  }
+
+  return targets;
 }
 
 async function resolveUnknownMentions(
@@ -478,4 +660,16 @@ function sanitizeRememberText(text: string): string {
 
 function sanitizeChannelName(channelName: string): string {
   return channelName.trim().replace(/^#+/, "").trim().toLowerCase();
+}
+
+function sanitizeScheduledMessageText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function formatScheduledMessageCreatedStatus(message: ScheduledMessage): string {
+  const targetText = message.targetUsers.map((target) => `@${target.username}`).join(", ");
+  const repeatText =
+    message.repeat === "none" ? "once" : `every ${message.repeat === "daily" ? "day" : "week"}`;
+
+  return `> ⏰ Scheduled ${repeatText} for ${message.runDate} at ${message.runTime} to ${targetText}`;
 }

--- a/src/openai/responder.ts
+++ b/src/openai/responder.ts
@@ -13,6 +13,7 @@ import { loadSystemPrompt } from "./systemPrompt.js";
 import type {
   ApiMemory,
   BotToolExecutor,
+  CreateScheduledMessageToolInput,
   RememberPersonToolInput,
   ResponderResult,
   SendChannelMessageToolInput,
@@ -69,7 +70,7 @@ export class OpenAIResponder {
         };
       }
 
-      for (let toolIteration = 0; toolIteration < 4; toolIteration += 1) {
+      for (let toolIteration = 0; toolIteration < 5; toolIteration += 1) {
         const input: ResponseInputItem[] = [...memory, ...turnItems];
         const response = await this.client.responses.create({
           model: this.config.openaiModel,
@@ -133,6 +134,16 @@ export class OpenAIResponder {
 
         if (toolCall.name === "remember_person") {
           const result = await executeRememberPersonTool(toolCall, toolExecutor, this.logger);
+          turnItems.push(createFunctionCallOutput(toolCall, result));
+          continue;
+        }
+
+        if (toolCall.name === "create_scheduled_message") {
+          const result = await executeCreateScheduledMessageTool(
+            toolCall,
+            toolExecutor,
+            this.logger,
+          );
           turnItems.push(createFunctionCallOutput(toolCall, result));
           continue;
         }
@@ -254,6 +265,54 @@ const botControlTools = [
   },
   {
     type: "function",
+    name: "create_scheduled_message",
+    description:
+      "Non-terminal action. Schedule Ben to send a message at a specific future bot-local date and time, optionally repeating daily or weekly. Use only when the user clearly asks Ben to remind, ask, or ping real users later. After this succeeds or fails, continue with send_message, wait_for_more_messages, or sleep_conversation.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        message: {
+          type: "string",
+          description:
+            "The message Ben should send later, without leading pings. Must be 1-1000 characters.",
+        },
+        target_usernames: {
+          type: "array",
+          description:
+            "Discord usernames to ping when sending. Use real user names only. Do not include @everyone, @here, roles, or empty strings.",
+          items: {
+            type: "string",
+          },
+        },
+        channel: {
+          type: ["string", "null"],
+          description:
+            "Target channel name, with or without #. Use null for the current channel.",
+        },
+        run_date: {
+          type: "string",
+          description:
+            "First run date in YYYY-MM-DD using the bot's current local date from the prompt.",
+        },
+        run_time: {
+          type: "string",
+          description:
+            "First run time in 24-hour HH:mm using the bot's current local time from the prompt.",
+        },
+        repeat: {
+          type: "string",
+          enum: ["none", "daily", "weekly"],
+          description:
+            "Use none for one-time schedules, daily for every day, or weekly for every week anchored to run_date.",
+        },
+      },
+      required: ["message", "target_usernames", "channel", "run_date", "run_time", "repeat"],
+    },
+  },
+  {
+    type: "function",
     name: "wait_for_more_messages",
     description:
       "Terminal action. Stay awake and wait for follow-up messages without sending a text response. Execution pauses until new human messages arrive.",
@@ -298,6 +357,7 @@ const botControlTools = [
 
 type BotControlToolName =
   | "remember_person"
+  | "create_scheduled_message"
   | "send_message"
   | "wait_for_more_messages"
   | "sleep_conversation";
@@ -312,6 +372,7 @@ function isBotControlToolName(name: string): name is BotControlToolName {
   return (
     name === "send_message" ||
     name === "remember_person" ||
+    name === "create_scheduled_message" ||
     name === "wait_for_more_messages" ||
     name === "sleep_conversation"
   );
@@ -379,6 +440,37 @@ async function executeSendChannelMessageTool(
       channel: result.channel,
     };
   }
+
+  return result;
+}
+
+async function executeCreateScheduledMessageTool(
+  toolCall: ResponseFunctionToolCall,
+  toolExecutor: BotToolExecutor,
+  logger: Logger,
+): Promise<Record<string, unknown>> {
+  const input = parseCreateScheduledMessageAction(toolCall);
+
+  if (input.message.length === 0 || input.message.length > 1_000) {
+    logger.warn("openai.invalid_create_scheduled_message_text", {
+      chars: input.message.length,
+    });
+    return {
+      ok: false,
+      error: "scheduled message must be 1-1000 characters",
+    };
+  }
+
+  if (input.targetUsernames.length === 0) {
+    logger.warn("openai.create_scheduled_message_missing_targets");
+    return {
+      ok: false,
+      error: "scheduled message requires at least one real target username",
+    };
+  }
+
+  const result = await toolExecutor.createScheduledMessage(input);
+  logger.info("openai.create_scheduled_message_result", result);
 
   return result;
 }
@@ -575,6 +667,56 @@ function parseRememberPersonAction(toolCall: ResponseFunctionToolCall): Remember
     username: typeof args.username === "string" ? trimUsername(args.username) : "",
     name: typeof args.name === "string" ? args.name.trim() : "",
   };
+}
+
+function parseCreateScheduledMessageAction(
+  toolCall: ResponseFunctionToolCall,
+): CreateScheduledMessageToolInput {
+  const args = parseFunctionArguments(toolCall.arguments);
+
+  return {
+    message: typeof args.message === "string" ? args.message.trim() : "",
+    targetUsernames: parseTargetUsernames(args.target_usernames),
+    channel:
+      typeof args.channel === "string" && args.channel.trim().length > 0
+        ? args.channel.trim().replace(/^#+/, "")
+        : null,
+    runDate: typeof args.run_date === "string" ? args.run_date.trim() : "",
+    runTime: typeof args.run_time === "string" ? args.run_time.trim() : "",
+    repeat: parseScheduleRepeat(args.repeat),
+  };
+}
+
+function parseTargetUsernames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const usernames = new Set<string>();
+
+  for (const item of value) {
+    if (typeof item !== "string") {
+      continue;
+    }
+
+    const username = trimUsername(item);
+
+    if (username.length === 0) {
+      continue;
+    }
+
+    usernames.add(username);
+  }
+
+  return [...usernames];
+}
+
+function parseScheduleRepeat(value: unknown): CreateScheduledMessageToolInput["repeat"] {
+  if (value === "daily" || value === "weekly") {
+    return value;
+  }
+
+  return "none";
 }
 
 function trimUsername(username: string): string {

--- a/src/openai/types.ts
+++ b/src/openai/types.ts
@@ -34,9 +34,37 @@ export type SendChannelMessageToolResult =
       error: string;
     };
 
+export type ScheduledMessageRepeat = "none" | "daily" | "weekly";
+
+export interface CreateScheduledMessageToolInput {
+  message: string;
+  targetUsernames: string[];
+  channel: string | null;
+  runDate: string;
+  runTime: string;
+  repeat: ScheduledMessageRepeat;
+}
+
+export type CreateScheduledMessageToolResult =
+  | {
+      ok: true;
+      id: string;
+      nextRunAt: string;
+      repeat: ScheduledMessageRepeat;
+      channel: string;
+      targetUsernames: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 export interface BotToolExecutor {
   rememberPerson(input: RememberPersonToolInput): Promise<RememberPersonToolResult>;
   sendChannelMessage(input: SendChannelMessageToolInput): Promise<SendChannelMessageToolResult>;
+  createScheduledMessage(
+    input: CreateScheduledMessageToolInput,
+  ): Promise<CreateScheduledMessageToolResult>;
 }
 
 export type ResponderResult =

--- a/src/prompts/system.txt
+++ b/src/prompts/system.txt
@@ -28,6 +28,19 @@ If someone asks you to send a message in a different Discord channel, call send_
 
 When someone clearly tells you a Discord username belongs to a real person, call remember_person with that username and name before your final terminal action. remember_person is not terminal: after it succeeds or fails, continue with send_message, wait_for_more_messages, or sleep_conversation. Do not announce the remember_person result yourself because the server will post a status message.
 
+If someone asks you to remind, ask, or ping real users later, call create_scheduled_message when you can determine all required fields. create_scheduled_message is not terminal: after it succeeds or fails, continue with send_message, wait_for_more_messages, or sleep_conversation.
+
+For create_scheduled_message:
+- message is the future message text only. Do not include leading @username pings in message.
+- target_usernames must contain the real Discord usernames to ping. For "remind me", use the username of the person who pinged Ben or made the request.
+- channel must be null for the current channel. Use a channel name only when the user explicitly asks for another channel.
+- run_date must be YYYY-MM-DD and run_time must be 24-hour HH:mm using the current bot time from the prompt.
+- repeat must be "none", "daily", or "weekly". Use "none" for one-time reminders.
+- Do not use @everyone, @here, roles, or broad groups as targets.
+- If the request is missing an exact future date or time, ask a short clarification instead of calling the tool.
+- If the user says "in 2 hours" or similar, calculate the exact run_date and run_time from the current bot time.
+- Do not announce the create_scheduled_message result yourself because the server will post a status message.
+
 Sometimes there may be multiple conversations going on and you might be waiting for a reply. If you don't want to send a message but still need to remain part of the conversation, call wait_for_more_messages and you'll get the follow-up messages afterwards. wait_for_more_messages is also a terminal action, and execution pauses until new human messages arrive.
 
 If a lightweight acknowledgement is better than a message, call send_message with text set to null, reaction set to exactly one standard Unicode emoji, and channel set to null. Use this for things like acknowledging, agreeing, laughing, thanking, or showing that you saw something. Do not use Discord custom emoji names, text aliases, words, or multiple emojis. Make SURE you prioritize reacting over sending messages when possible.


### PR DESCRIPTION
## Summary

- Add a `create_scheduled_message` OpenAI tool and prompt guidance so Ben can turn natural reminder requests into scheduled Discord messages.
- Add timezone-aware schedule parsing, JSON-backed scheduled message storage, and an interval scheduler that sends target user pings and handles one-time, daily, and weekly schedules.
- Wire scheduled messages into the Discord bot runtime, add configuration for storage/timezone/check interval, and document the feature in the README.

## Validation

- `pnpm lint`
- `pnpm build`