### PR TITLE
fix: use correct casing for usage command imports

### DIFF
--- a/src/app/createApplication.ts
+++ b/src/app/createApplication.ts
@@ -8,7 +8,7 @@ import type { DiscordGateway } from "../discord/DiscordGateway.js";
 import { DiscordPresence } from "../discord/DiscordPresence.js";
 import { createScheduledMessageDelivery } from "../discord/ScheduledMessageDelivery.js";
 import { DiscordTransport } from "../discord/DiscordTransport.js";
-import { handleUsageCommand, registerUsageCommand } from "../discord/UsageCommand.js";
+import { handleUsageCommand, registerUsageCommand } from "../discord/usageCommand.js";
 import { createScheduledMessageTool } from "../discord/tools/createScheduledMessage.js";
 import { createRememberPersonTool } from "../discord/tools/rememberPerson.js";
 import { createSendMessageTool } from "../discord/tools/sendChannelMessage.js";

--- a/src/discord/__tests__/UsageCommand.test.ts
+++ b/src/discord/__tests__/UsageCommand.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatUsageSummary, handleUsageCommand, registerUsageCommand } from "../UsageCommand.js";
+import { formatUsageSummary, handleUsageCommand, registerUsageCommand } from "../usageCommand.js";
 
 const summary = {
   day: "260810",


### PR DESCRIPTION
## What changed

- Updated the application import for the usage command module to match the tracked lowercase filename.
- Updated the usage command test import to use the same casing.

## Why

Railway builds on a case-sensitive Linux filesystem. The imports referenced `UsageCommand.js`, while the tracked source file is `usageCommand.ts`, causing TypeScript to fail with `TS2307` during deployment.

## Impact

The production build can resolve the usage command module on Linux, allowing the deployment to proceed past TypeScript compilation.

## Validation

- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed
- `pnpm test` — usage-command tests passed; the full suite has one unrelated pre-existing failure because `OpenAIModel.ts` uses reasoning effort `medium` while `OpenAIModel.test.ts` expects `low`