### PR TITLE
feat: support message IDs and reaction replies

### DIFF
--- a/src/__tests__/portableBehavior.test.ts
+++ b/src/__tests__/portableBehavior.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { escapeBroadcastMentions } from "../discord/mentions.js";
 import { calculateCostUsd, getModelPricing } from "../model/pricing.js";
-import { buildUserPrompt, formatGroupedMessages } from "../prompts/formatMessages.js";
+import { buildUserPrompt, formatMessages } from "../prompts/formatMessages.js";
 import { loadSystemPrompt } from "../prompts/systemPrompt.js";
 
 const messageBase = {
@@ -54,18 +54,21 @@ test("does not produce negative uncached usage", () => {
   assert.equal(cost, 0.00002);
 });
 
-test("groups consecutive messages and omits empty content", () => {
-  const result = formatGroupedMessages(
+test("preserves one addressable transcript line per non-empty message", () => {
+  const result = formatMessages(
     [
       { ...messageBase, id: "1", username: "makan", content: " hi " },
-      { ...messageBase, id: "2", username: "makan", content: "there" },
+      { ...messageBase, id: "2", username: "makan", content: "there\nfriend" },
       { ...messageBase, id: "3", username: "sam", content: " " },
       { ...messageBase, id: "4", username: "sam", content: "hello" },
     ],
     { makan: { name: "Makan" } },
   );
 
-  assert.equal(result, "makan (Makan): hi there\nsam: hello");
+  assert.equal(
+    result,
+    "<message_id:1> makan (Makan): hi\n<message_id:2> makan (Makan): there friend\n<message_id:4> sam: hello",
+  );
 });
 
 test("builds all optional prompt context in stable order", () => {
@@ -86,8 +89,8 @@ test("builds all optional prompt context in stable order", () => {
       "Known people:\n- makan is Makan",
       "Recent conversations:\n- They discussed lunch.",
       "Ben was pinged by makan (Makan).",
-      "Recent context:\nsam: earlier",
-      "New messages:\nmakan (Makan): hello",
+      "Recent context:\n<message_id:1> sam: earlier",
+      "New messages:\n<message_id:2> makan (Makan): hello",
     ].join("\n\n"),
   );
 });

--- a/src/app/BotSession.ts
+++ b/src/app/BotSession.ts
@@ -81,7 +81,7 @@ export class BotSession {
   private debounceTimer: NodeJS.Timeout | undefined;
   private idleTimer: NodeJS.Timeout | undefined;
   private typingTimer: NodeJS.Timeout | undefined;
-  private botMessageSequence = 0;
+  private activeMessageIds = new Set<string>();
   private activeCreator: ActiveConversationUser | undefined;
 
   /**
@@ -145,6 +145,8 @@ export class BotSession {
       return;
     }
 
+    this.activeMessageIds.add(message.id);
+
     if (this.mode === "processing") {
       this.queuedDuringProcessing.push(message);
       return;
@@ -202,22 +204,23 @@ export class BotSession {
   /**
    * Adds successful bot output to a channel's bounded recent context.
    *
-   * @param channelId - Channel that received the bot message.
-   * @param content - Delivered message content.
+   * @param message - Successfully delivered bot message with its real Discord identifier.
    */
-  recordBotMessage(channelId: string, content: string): void {
-    this.botMessageSequence += 1;
-    const message: HumanMessage = {
-      id: `ben:${String(Date.now())}:${String(this.botMessageSequence)}`,
-      channelId,
-      userId: "ben",
-      username: "Ben",
-      content,
-      createdAt: Date.now(),
-    };
+  recordBotMessage(message: HumanMessage): void {
     this.rememberMessage(message);
-    const queued = this.queuedWakes.find((wake) => wake.channelId === channelId);
+    if (message.channelId === this.activeChannelId) this.activeMessageIds.add(message.id);
+    const queued = this.queuedWakes.find((wake) => wake.channelId === message.channelId);
     if (queued !== undefined) queued.messages.push(message);
+  }
+
+  /**
+   * Checks whether a Discord message identifier is present in the active transcript.
+   *
+   * @param messageId - Candidate target emitted by the model.
+   * @returns Whether the current conversation exposed that exact message.
+   */
+  isMessageInActiveConversation(messageId: string): boolean {
+    return this.activeMessageIds.has(messageId);
   }
 
   /** Starts a conversation from a ping or promoted queued wake. */
@@ -229,6 +232,7 @@ export class BotSession {
     this.activeChannelId = first.channelId;
     this.pendingBatch = messages;
     this.pendingRecentContext = recentContext;
+    this.activeMessageIds = new Set([...recentContext, ...messages].map((message) => message.id));
     this.queuedDuringProcessing = [];
     this.history = [];
     this.presence.setPresence({ status: "online" });
@@ -441,6 +445,7 @@ export class BotSession {
     this.pendingRecentContext = [];
     this.queuedDuringProcessing = [];
     this.history = [];
+    this.activeMessageIds.clear();
     this.activeCreator = undefined;
     this.typingByChannel.clear();
     this.presence.setPresence({ status: "idle" });

--- a/src/app/ChatTransport.ts
+++ b/src/app/ChatTransport.ts
@@ -1,5 +1,18 @@
+export type DeliveredMessage = {
+  id: string;
+  createdAt: number;
+};
+
+export type SendMessageOptions = {
+  replyTo?: string;
+};
+
 export type ChatTransport = {
-  sendMessage(channelId: string, text: string): Promise<void>;
+  sendMessage(
+    channelId: string,
+    text: string,
+    options?: SendMessageOptions,
+  ): Promise<DeliveredMessage>;
   sendTyping(channelId: string): Promise<void>;
   logStatus(message: string, details?: Readonly<Record<string, unknown>>): Promise<void>;
 };

--- a/src/app/__tests__/BotSession.test.ts
+++ b/src/app/__tests__/BotSession.test.ts
@@ -125,7 +125,10 @@ test("starts sleeping, keeps bounded channel context, and batches an awake chann
   assert.doesNotMatch(prompt, /old-1/);
   assert.match(prompt, /old-2/);
   assert.match(prompt, /old-6/);
-  assert.match(prompt, /New messages:\nMakan: ping follow-up/);
+  assert.match(
+    prompt,
+    /New messages:\n<message_id:ping> Makan: ping\n<message_id:follow-up> Makan: follow-up/,
+  );
   assert.deepEqual(presence.values[0], { status: "online" });
   assert.deepEqual(transport.messages, [{ channelId: "channel-a", text: "hey" }]);
 });
@@ -181,7 +184,8 @@ test("queues pinged channels FIFO and promotes each only after sleep", async (t)
   await until(() => orchestrator.calls.length === 3 && transport.messages.length === 1);
 
   assert.match(orchestrator.calls[0]?.userText ?? "", /a-ping/);
-  assert.match(orchestrator.calls[1]?.userText ?? "", /b-ping b-more/);
+  assert.match(orchestrator.calls[1]?.userText ?? "", /b-ping/);
+  assert.match(orchestrator.calls[1]?.userText ?? "", /b-more/);
   assert.match(orchestrator.calls[2]?.userText ?? "", /c-ping/);
   assert.deepEqual(
     orchestrator.calls.map((call) => call.history),
@@ -308,11 +312,22 @@ test("includes successful recorded bot output in that channel's next wake contex
   const { session } = createSession(orchestrator);
   t.after(() => session.stop());
 
-  session.recordBotMessage("channel-b", "cross-channel hello");
+  session.recordBotMessage({
+    id: "discord-bot-message",
+    channelId: "channel-b",
+    userId: "ben-user",
+    username: "Ben",
+    content: "cross-channel hello",
+    createdAt: 123,
+  });
   session.handleMessage(message("ping", "channel-b", "B"), true);
   await until(() => orchestrator.calls.length === 1);
 
-  assert.match(orchestrator.calls[0]?.userText ?? "", /Recent context:\nBen: cross-channel hello/);
+  assert.match(
+    orchestrator.calls[0]?.userText ?? "",
+    /Recent context:\n<message_id:discord-bot-message> Ben: cross-channel hello/,
+  );
+  assert.equal(session.isMessageInActiveConversation("discord-bot-message"), true);
 });
 
 test("rejects invalid timing overrides", () => {

--- a/src/app/__tests__/Composition.test.ts
+++ b/src/app/__tests__/Composition.test.ts
@@ -59,7 +59,10 @@ class FakeGateway implements DiscordGateway {
   async fetchGuildChannels() {
     return [];
   }
-  async sendMessage() {}
+  async sendMessage() {
+    return { id: "sent", createdAt: 0 };
+  }
+  async addReaction() {}
   async sendTyping() {}
   setPresence() {}
   async registerCommand(): Promise<"registered"> {

--- a/src/app/createApplication.ts
+++ b/src/app/createApplication.ts
@@ -11,6 +11,7 @@ import { DiscordTransport } from "../discord/DiscordTransport.js";
 import { handleUsageCommand, registerUsageCommand } from "../discord/usageCommand.js";
 import { createScheduledMessageTool } from "../discord/tools/createScheduledMessage.js";
 import { createRememberNameTool } from "../discord/tools/rememberName.js";
+import { createReactToMessageTool } from "../discord/tools/reactToMessage.js";
 import { createSendMessageTool } from "../discord/tools/sendChannelMessage.js";
 import type { Model } from "../model/Model.js";
 import { OpenAIUsageStore } from "../model/openai/OpenAIUsageStore.js";
@@ -55,7 +56,25 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
   const { env, logger, gateway } = dependencies;
   const users = new UserMentionDirectory();
   const channels = new ChannelMentionDirectory();
-  const transport = new DiscordTransport(gateway, users, channels, env.discordLogChannelId, logger);
+  let session!: BotSession;
+  const transport = new DiscordTransport(
+    gateway,
+    users,
+    channels,
+    env.discordLogChannelId,
+    logger,
+    (channelId, text, delivery) => {
+      const botUser = gateway.getBotUser();
+      session.recordBotMessage({
+        id: delivery.id,
+        channelId,
+        userId: botUser?.id ?? "ben",
+        username: botUser?.username ?? "Ben",
+        content: text,
+        createdAt: delivery.createdAt,
+      });
+    },
+  );
   const presence = new DiscordPresence(gateway);
   const summaries = new ConversationSummaryStore(paths.summaries, logger);
   const people = new KnownPeopleStore(paths.people, logger);
@@ -67,12 +86,21 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
     logger,
   );
 
-  let session: BotSession;
   const tools = new ToolRegistry([waitTool, sleepTool]);
   tools.register(
     createSendMessageTool({
       transport,
       getActiveChannelId: () => session.getActiveChannelId(),
+      isMessageInActiveConversation: (messageId) =>
+        session.isMessageInActiveConversation(messageId),
+    }),
+  );
+  tools.register(
+    createReactToMessageTool({
+      gateway,
+      getActiveChannelId: () => session.getActiveChannelId(),
+      isMessageInActiveConversation: (messageId) =>
+        session.isMessageInActiveConversation(messageId),
     }),
   );
   tools.register(

--- a/src/discord/DiscordGateway.ts
+++ b/src/discord/DiscordGateway.ts
@@ -42,6 +42,12 @@ export type DiscordCommandDefinition = {
 
 export type DiscordSendOptions = {
   allowUserMentions: boolean;
+  replyToMessageId?: string;
+};
+
+export type DiscordSentMessage = {
+  id: string;
+  createdAt: number;
 };
 
 export type DiscordGatewayHandlers = {
@@ -60,7 +66,12 @@ export type DiscordGateway = {
   fetchChannel(channelId: string): Promise<DiscordChannel | undefined>;
   searchGuildMembers(guildId: string, query: string): Promise<readonly DiscordMember[]>;
   fetchGuildChannels(guildId: string): Promise<readonly DiscordChannel[]>;
-  sendMessage(channelId: string, content: string, options: DiscordSendOptions): Promise<void>;
+  sendMessage(
+    channelId: string,
+    content: string,
+    options: DiscordSendOptions,
+  ): Promise<DiscordSentMessage>;
+  addReaction(channelId: string, messageId: string, emoji: string): Promise<void>;
   sendTyping(channelId: string): Promise<void>;
   setPresence(status: "idle" | "online"): void;
   registerCommand(command: DiscordCommandDefinition): Promise<"registered" | "updated">;

--- a/src/discord/DiscordJsGateway.ts
+++ b/src/discord/DiscordJsGateway.ts
@@ -5,6 +5,8 @@ import type {
   DiscordGateway,
   DiscordGatewayHandlers,
   DiscordMember,
+  DiscordSendOptions,
+  DiscordSentMessage,
   DiscordUser,
 } from "./DiscordGateway.js";
 
@@ -148,16 +150,46 @@ export class DiscordJsGateway implements DiscordGateway {
   async sendMessage(
     channelId: string,
     content: string,
-    options: { allowUserMentions: boolean },
-  ): Promise<void> {
+    options: DiscordSendOptions,
+  ): Promise<DiscordSentMessage> {
     const channel = await this.client.channels.fetch(channelId);
     if (!channel?.isSendable()) {
       throw new Error("Discord channel is not sendable.");
     }
-    await channel.send({
+    const message = await channel.send({
       content,
-      allowedMentions: { parse: options.allowUserMentions ? ["users"] : [] },
+      allowedMentions: {
+        parse: options.allowUserMentions ? ["users"] : [],
+        repliedUser: false,
+      },
+      ...(options.replyToMessageId === undefined
+        ? {}
+        : {
+            reply: {
+              messageReference: options.replyToMessageId,
+              failIfNotExists: false,
+            },
+          }),
     });
+    return { id: message.id, createdAt: message.createdTimestamp };
+  }
+
+  /**
+   * Adds a reaction to a message in a text-based channel.
+   *
+   * @param channelId - Channel containing the target message.
+   * @param messageId - Discord identifier of the target message.
+   * @param emoji - Unicode or custom Discord emoji identifier to add.
+   * @returns A promise that resolves after Discord accepts the reaction.
+   * @throws When the channel is unavailable or does not contain messages.
+   */
+  async addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel?.isTextBased()) {
+      throw new Error("Discord reaction channel is not text-based.");
+    }
+    const message = await channel.messages.fetch(messageId);
+    await message.react(emoji);
   }
 
   /**

--- a/src/discord/DiscordTransport.ts
+++ b/src/discord/DiscordTransport.ts
@@ -1,4 +1,4 @@
-import type { ChatTransport } from "../app/ChatTransport.js";
+import type { ChatTransport, DeliveredMessage, SendMessageOptions } from "../app/ChatTransport.js";
 import type { Logger } from "../logger.js";
 import {
   ChannelMentionDirectory,
@@ -18,6 +18,7 @@ export class DiscordTransport implements ChatTransport {
    * @param channels - Shared verified channel mention directory.
    * @param logChannelId - Optional Discord destination for operational status.
    * @param logger - Logger used when optional status delivery is unavailable.
+   * @param onMessageSent - Optional callback that records successful conversational delivery.
    */
   constructor(
     private readonly gateway: DiscordGateway,
@@ -25,6 +26,11 @@ export class DiscordTransport implements ChatTransport {
     private readonly channels: ChannelMentionDirectory,
     private readonly logChannelId: string | undefined,
     private readonly logger: Pick<Logger, "debug">,
+    private readonly onMessageSent?: (
+      channelId: string,
+      text: string,
+      delivery: DeliveredMessage,
+    ) => void,
   ) {}
 
   /**
@@ -32,10 +38,15 @@ export class DiscordTransport implements ChatTransport {
    *
    * @param channelId - Destination Discord channel identifier.
    * @param text - Message text to send.
-   * @returns A promise that resolves after delivery.
+   * @param options - Optional Discord-independent delivery behavior.
+   * @returns The real Discord identifier and creation time of the delivered message.
    * @throws When the destination channel cannot be found or is not sendable.
    */
-  async sendMessage(channelId: string, text: string): Promise<void> {
+  async sendMessage(
+    channelId: string,
+    text: string,
+    options: SendMessageOptions = {},
+  ): Promise<DeliveredMessage> {
     const channel = await this.gateway.fetchChannel(channelId);
     if (channel === undefined) throw new Error("Discord response channel was not found.");
 
@@ -44,9 +55,12 @@ export class DiscordTransport implements ChatTransport {
     await resolveUnknownMentions(this.gateway, channel, safeText, this.users, this.channels);
     const withChannels = this.channels.convertNamesToMentions(safeText);
     const withUsers = this.users.convertUsernamesToMentions(withChannels);
-    await this.gateway.sendMessage(channelId, escapeBroadcastMentions(withUsers), {
+    const delivery = await this.gateway.sendMessage(channelId, escapeBroadcastMentions(withUsers), {
       allowUserMentions: true,
+      ...(options.replyTo === undefined ? {} : { replyToMessageId: options.replyTo }),
     });
+    this.onMessageSent?.(channelId, text, delivery);
+    return delivery;
   }
 
   /**

--- a/src/discord/__tests__/DiscordBoundary.test.ts
+++ b/src/discord/__tests__/DiscordBoundary.test.ts
@@ -105,15 +105,21 @@ test("transport resolves unique names and sends only safe mentions", async () =>
   const gateway = new FakeDiscordGateway();
   gateway.channels = [general, { id: "channel-2", name: "plans", guildId: "guild-1" }];
   gateway.members = [{ ...human, displayName: "Makan A" }];
+  const recorded: unknown[] = [];
   const transport = new DiscordTransport(
     gateway,
     new UserMentionDirectory(),
     new ChannelMentionDirectory(),
     "log-channel",
     { debug() {} },
+    (channelId, text, delivery) => recorded.push({ channelId, text, delivery }),
   );
 
-  await transport.sendMessage("channel-1", "hey @makan in #plans, not @everyone or @here");
+  const delivery = await transport.sendMessage(
+    "channel-1",
+    "hey @makan in #plans, not @everyone or @here",
+    { replyTo: "message-1" },
+  );
   await transport.logStatus("@everyone diagnostics");
   await transport.sendTyping("channel-1");
 
@@ -121,7 +127,7 @@ test("transport resolves unique names and sends only safe mentions", async () =>
     {
       channelId: "channel-1",
       content: "hey <@user-1> in <#channel-2>, not @\u200Beveryone or @\u200Bhere",
-      options: { allowUserMentions: true },
+      options: { allowUserMentions: true, replyToMessageId: "message-1" },
     },
     {
       channelId: "log-channel",
@@ -131,6 +137,14 @@ test("transport resolves unique names and sends only safe mentions", async () =>
   ]);
   assert.deepEqual(gateway.typing, ["channel-1"]);
   assert.deepEqual(gateway.memberSearches, [{ guildId: "guild-1", query: "makan" }]);
+  assert.deepEqual(delivery, { id: "sent-1", createdAt: 1 });
+  assert.deepEqual(recorded, [
+    {
+      channelId: "channel-1",
+      text: "hey @makan in #plans, not @everyone or @here",
+      delivery: { id: "sent-1", createdAt: 1 },
+    },
+  ]);
 });
 
 test("transport does not guess ambiguous users or channels", async () => {
@@ -190,6 +204,7 @@ class FakeDiscordGateway implements DiscordGateway {
   typing: string[] = [];
   presences: Array<"idle" | "online"> = [];
   memberSearches: Array<{ guildId: string; query: string }> = [];
+  reactions: Array<{ channelId: string; messageId: string; emoji: string }> = [];
 
   setHandlers(handlers: DiscordGatewayHandlers): void {
     this.handlers = handlers;
@@ -213,12 +228,12 @@ class FakeDiscordGateway implements DiscordGateway {
   async fetchGuildChannels(): Promise<readonly DiscordChannel[]> {
     return this.channels;
   }
-  async sendMessage(
-    channelId: string,
-    content: string,
-    options: DiscordSendOptions,
-  ): Promise<void> {
+  async sendMessage(channelId: string, content: string, options: DiscordSendOptions) {
     this.sent.push({ channelId, content, options });
+    return { id: `sent-${String(this.sent.length)}`, createdAt: this.sent.length };
+  }
+  async addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+    this.reactions.push({ channelId, messageId, emoji });
   }
   async sendTyping(channelId: string): Promise<void> {
     this.typing.push(channelId);

--- a/src/discord/__tests__/DiscordTools.test.ts
+++ b/src/discord/__tests__/DiscordTools.test.ts
@@ -5,6 +5,7 @@ import type {
   CreateScheduledMessageInput,
   ScheduledMessage,
 } from "../../storage/ScheduledMessageStore.js";
+import type { SendMessageOptions } from "../../app/ChatTransport.js";
 import type { Tool } from "../../tools/Tool.js";
 import { ToolRegistry } from "../../tools/ToolRegistry.js";
 import { sleepTool, waitTool } from "../../tools/conversationControls.js";
@@ -19,6 +20,7 @@ import type {
 } from "../DiscordGateway.js";
 import { createScheduledMessageDelivery } from "../ScheduledMessageDelivery.js";
 import { createScheduledMessageTool } from "../tools/createScheduledMessage.js";
+import { createReactToMessageTool } from "../tools/reactToMessage.js";
 import { createRememberNameTool } from "../tools/rememberName.js";
 import { createSendMessageTool } from "../tools/sendChannelMessage.js";
 
@@ -98,7 +100,7 @@ test("message sends one or more messages and defaults to continuing", async () =
   const tool = createSendTool(transport);
   assert.deepEqual(await execute(tool, { text: " hello " }), {
     type: "continue",
-    result: { ok: true, sentCount: 1 },
+    result: { ok: true, sentCount: 1, messageIds: ["sent-1"] },
   });
   assert.deepEqual(
     await execute(tool, {
@@ -108,7 +110,7 @@ test("message sends one or more messages and defaults to continuing", async () =
     }),
     {
       type: "finish",
-      result: { ok: true, sentCount: 2 },
+      result: { ok: true, sentCount: 2, messageIds: ["sent-2", "sent-3"] },
       outcome: { type: "wait" },
     },
   );
@@ -127,7 +129,7 @@ test("message sleeps with a summary only after complete delivery", async () => {
     }),
     {
       type: "finish",
-      result: { ok: true, sentCount: 2 },
+      result: { ok: true, sentCount: 2, messageIds: ["sent-1", "sent-2"] },
       outcome: { type: "sleep", summary: "Finished the work." },
     },
   );
@@ -151,9 +153,51 @@ test("message reports partial delivery and does not apply its next action", asyn
 
   assert.deepEqual(result, {
     type: "continue",
-    result: { ok: false, error: "Error: send failed", sentCount: 1 },
+    result: { ok: false, error: "Error: send failed", sentCount: 1, messageIds: ["sent-1"] },
   });
   assert.deepEqual(transport.messages, ["sent"]);
+});
+
+test("message replies only with the first text and validates the reference", async () => {
+  const transport = new FakeMessageTransport();
+  const tool = createSendTool(transport);
+
+  await execute(tool, { text: ["reply", "follow-up"], reply_to: "message-1" });
+  assert.deepEqual(transport.options, [{ replyTo: "message-1" }, undefined]);
+
+  const rejected = await execute(tool, { text: "not sent", reply_to: "unknown" });
+  assert.match(JSON.stringify(rejected), /reply_to is not in the active conversation/);
+  assert.deepEqual(transport.messages, ["reply", "follow-up"]);
+});
+
+test("reaction targets only an exact message from the active conversation", async () => {
+  const gateway = new FakeGateway();
+  const tool = createReactToMessageTool({
+    gateway,
+    getActiveChannelId: () => "general",
+    isMessageInActiveConversation: (messageId) => messageId === "message-1",
+  });
+
+  assert.deepEqual(
+    await execute(tool, {
+      message_id: "message-1",
+      emoji: "🔥",
+      next_action: "wait",
+      sleep_summary: null,
+    }),
+    {
+      type: "finish",
+      result: { ok: true, messageId: "message-1", emoji: "🔥" },
+      outcome: { type: "wait" },
+    },
+  );
+  assert.deepEqual(gateway.reactions, [
+    { channelId: "general", messageId: "message-1", emoji: "🔥" },
+  ]);
+
+  const rejected = await execute(tool, { message_id: "not-visible", emoji: "👍" });
+  assert.match(JSON.stringify(rejected), /not in the active conversation/);
+  assert.equal(gateway.reactions.length, 1);
 });
 
 test("scheduled-message tool verifies targets and stores a future local schedule", async () => {
@@ -315,8 +359,14 @@ test("Discord capability tools register through the generic tool registry", () =
     },
     [],
   );
+  const reactToMessage = createReactToMessageTool({
+    gateway,
+    getActiveChannelId: () => "general",
+    isMessageInActiveConversation: () => true,
+  });
   const registry = new ToolRegistry([
     sendMessage,
+    reactToMessage,
     rememberName,
     scheduledMessage,
     waitTool,
@@ -325,7 +375,7 @@ test("Discord capability tools register through the generic tool registry", () =
 
   assert.deepEqual(
     registry.definitions().map(({ name }) => name),
-    ["message", "remember_name", "create_scheduled_message", "wait", "sleep"],
+    ["message", "react_to_message", "remember_name", "create_scheduled_message", "wait", "sleep"],
   );
 });
 
@@ -333,6 +383,7 @@ function createSendTool(transport = new FakeMessageTransport()): Tool {
   return createSendMessageTool({
     transport,
     getActiveChannelId: () => "general",
+    isMessageInActiveConversation: (messageId) => messageId === "message-1",
   });
 }
 
@@ -393,12 +444,15 @@ async function execute(tool: Tool, argumentsValue: unknown) {
 
 class FakeMessageTransport {
   messages: string[] = [];
+  options: Array<SendMessageOptions | undefined> = [];
 
   constructor(private readonly failAt?: number) {}
 
-  async sendMessage(_channelId: string, text: string): Promise<void> {
+  async sendMessage(_channelId: string, text: string, options?: SendMessageOptions) {
     if (this.messages.length === this.failAt) throw new Error("send failed");
     this.messages.push(text);
+    this.options.push(options);
+    return { id: `sent-${String(this.messages.length)}`, createdAt: this.messages.length };
   }
 }
 
@@ -407,6 +461,7 @@ class FakeGateway implements DiscordGateway {
   members: DiscordMember[] = [];
   memberError: unknown;
   sent: Array<{ channelId: string; content: string; options: DiscordSendOptions }> = [];
+  reactions: Array<{ channelId: string; messageId: string; emoji: string }> = [];
   setHandlers(_handlers: DiscordGatewayHandlers): void {}
   async login(_token: string): Promise<void> {}
   async destroy(): Promise<void> {}
@@ -423,12 +478,12 @@ class FakeGateway implements DiscordGateway {
   async fetchGuildChannels(): Promise<readonly DiscordChannel[]> {
     return this.channels;
   }
-  async sendMessage(
-    channelId: string,
-    content: string,
-    options: DiscordSendOptions,
-  ): Promise<void> {
+  async sendMessage(channelId: string, content: string, options: DiscordSendOptions) {
     this.sent.push({ channelId, content, options });
+    return { id: `sent-${String(this.sent.length)}`, createdAt: this.sent.length };
+  }
+  async addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+    this.reactions.push({ channelId, messageId, emoji });
   }
   async sendTyping(_channelId: string): Promise<void> {}
   setPresence(_status: "idle" | "online"): void {}

--- a/src/discord/tools/reactToMessage.ts
+++ b/src/discord/tools/reactToMessage.ts
@@ -1,0 +1,82 @@
+import type { Tool } from "../../tools/Tool.js";
+import { createActionableTool } from "../../tools/createActionableTool.js";
+import type { DiscordGateway } from "../DiscordGateway.js";
+import { parseArguments, sanitizeText } from "./toolSupport.js";
+
+const MAX_EMOJI_LENGTH = 100;
+
+export type ReactToMessageToolDependencies = {
+  gateway: Pick<DiscordGateway, "addReaction">;
+  getActiveChannelId(): string | undefined;
+  isMessageInActiveConversation(messageId: string): boolean;
+};
+
+/**
+ * Creates the current-conversation Discord reaction tool.
+ *
+ * @param dependencies - Reaction delivery and active-transcript validation capabilities.
+ * @returns An actionable tool that reacts only to messages exposed in the active transcript.
+ */
+export function createReactToMessageTool(dependencies: ReactToMessageToolDependencies): Tool {
+  return createActionableTool({
+    definition: {
+      name: "react_to_message",
+      description:
+        "Add one emoji reaction to a message from the active conversation using its exact message_id.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          message_id: {
+            type: "string",
+            minLength: 1,
+            description: "Exact message_id shown in the transcript or returned after sending.",
+          },
+          emoji: {
+            type: "string",
+            minLength: 1,
+            maxLength: MAX_EMOJI_LENGTH,
+            description: "One Unicode emoji or Discord custom emoji identifier.",
+          },
+        },
+        required: ["message_id", "emoji"],
+      },
+    },
+    async execute(call) {
+      const input = parseArguments(call.arguments);
+      const messageId = sanitizeText(input.message_id);
+      const emoji = sanitizeText(input.emoji);
+
+      if (messageId.length === 0) {
+        return { ok: false, result: { ok: false, error: "message_id must be non-empty" } };
+      }
+      if (emoji.length === 0 || emoji.length > MAX_EMOJI_LENGTH) {
+        return {
+          ok: false,
+          result: {
+            ok: false,
+            error: `emoji must contain 1-${String(MAX_EMOJI_LENGTH)} characters`,
+          },
+        };
+      }
+      if (!dependencies.isMessageInActiveConversation(messageId)) {
+        return {
+          ok: false,
+          result: { ok: false, error: "message_id is not in the active conversation" },
+        };
+      }
+
+      const channelId = dependencies.getActiveChannelId();
+      if (channelId === undefined) {
+        return { ok: false, result: { ok: false, error: "no active Discord channel" } };
+      }
+
+      try {
+        await dependencies.gateway.addReaction(channelId, messageId, emoji);
+        return { ok: true, result: { ok: true, messageId, emoji } };
+      } catch (error) {
+        return { ok: false, result: { ok: false, error: String(error) } };
+      }
+    },
+  });
+}

--- a/src/discord/tools/sendChannelMessage.ts
+++ b/src/discord/tools/sendChannelMessage.ts
@@ -9,6 +9,7 @@ const MAX_MESSAGE_LENGTH = 2_000;
 export type SendMessageToolDependencies = {
   transport: Pick<ChatTransport, "sendMessage">;
   getActiveChannelId(): string | undefined;
+  isMessageInActiveConversation(messageId: string): boolean;
 };
 
 /**
@@ -38,8 +39,13 @@ export function createSendMessageTool(dependencies: SendMessageToolDependencies)
               },
             ],
           },
+          reply_to: {
+            type: ["string", "null"],
+            description:
+              "Exact message_id to reply to, or null for a normal message. With multiple texts, only the first is a reply.",
+          },
         },
-        required: ["text"],
+        required: ["text", "reply_to"],
       },
     },
     async execute(call) {
@@ -48,31 +54,62 @@ export function createSendMessageTool(dependencies: SendMessageToolDependencies)
       if (!messages.ok) {
         return { ok: false, result: { ok: false, error: messages.error } };
       }
+      const replyTo = parseReplyTo(input.reply_to);
+      if (!replyTo.ok) {
+        return { ok: false, result: { ok: false, error: replyTo.error } };
+      }
+      if (
+        replyTo.messageId !== undefined &&
+        !dependencies.isMessageInActiveConversation(replyTo.messageId)
+      ) {
+        return {
+          ok: false,
+          result: { ok: false, error: "reply_to is not in the active conversation" },
+        };
+      }
 
       const channelId = dependencies.getActiveChannelId();
       if (channelId === undefined) {
         return { ok: false, result: { ok: false, error: "no active Discord channel" } };
       }
 
-      let sentCount = 0;
+      const messageIds: string[] = [];
       try {
-        for (const text of messages.values) {
-          await dependencies.transport.sendMessage(channelId, text);
-          sentCount += 1;
+        for (const [index, text] of messages.values.entries()) {
+          const delivery = await dependencies.transport.sendMessage(
+            channelId,
+            text,
+            index === 0 && replyTo.messageId !== undefined
+              ? { replyTo: replyTo.messageId }
+              : undefined,
+          );
+          messageIds.push(delivery.id);
         }
       } catch (error) {
         return {
           ok: false,
-          result: { ok: false, error: String(error), sentCount },
+          result: { ok: false, error: String(error), sentCount: messageIds.length, messageIds },
         };
       }
 
-      return { ok: true, result: { ok: true, sentCount } };
+      return { ok: true, result: { ok: true, sentCount: messageIds.length, messageIds } };
     },
   });
 }
 
 type ParsedMessages = { ok: true; values: string[] } | { ok: false; error: string };
+type ParsedReplyTo = { ok: true; messageId?: string } | { ok: false; error: string };
+
+/** Parses an optional exact message reference without accepting other value types. */
+function parseReplyTo(value: unknown): ParsedReplyTo {
+  if (value === null || value === undefined) return { ok: true };
+  if (typeof value !== "string")
+    return { ok: false, error: "reply_to must be a message_id or null" };
+  const messageId = value.trim();
+  return messageId.length === 0
+    ? { ok: false, error: "reply_to must be a non-empty message_id or null" }
+    : { ok: true, messageId };
+}
 
 /** Validates and normalizes one message or an ordered message batch. */
 function parseMessages(value: unknown): ParsedMessages {

--- a/src/prompts/formatMessages.ts
+++ b/src/prompts/formatMessages.ts
@@ -17,45 +17,26 @@ export type UserPromptOptions = {
 };
 
 /**
- * Groups consecutive messages from the same speaker.
+ * Formats messages as individually addressable transcript lines.
  *
  * @param messages - Human messages in chronological order.
  * @param knownPeople - Optional mapping from usernames to real names.
- * @returns One prompt line per consecutive raw username.
+ * @returns One prompt line per non-empty Discord message.
  */
-export function formatGroupedMessages(
+export function formatMessages(
   messages: readonly HumanMessage[],
   knownPeople: KnownPeople = {},
 ): string {
-  const lines: string[] = [];
-  let currentUsername: string | undefined;
-  let currentContent: string[] = [];
-
-  for (const message of messages) {
-    const content = message.content.trim();
-
-    if (content.length === 0) {
-      continue;
-    }
-
-    if (message.username !== currentUsername) {
-      if (currentUsername !== undefined && currentContent.length > 0) {
-        lines.push(`${formatSpeaker(currentUsername, knownPeople)}: ${currentContent.join(" ")}`);
-      }
-
-      currentUsername = message.username;
-      currentContent = [content];
-      continue;
-    }
-
-    currentContent.push(content);
-  }
-
-  if (currentUsername !== undefined && currentContent.length > 0) {
-    lines.push(`${formatSpeaker(currentUsername, knownPeople)}: ${currentContent.join(" ")}`);
-  }
-
-  return lines.join("\n");
+  return messages
+    .flatMap((message) => {
+      const content = message.content.trim().replace(/\s*\r?\n\s*/g, " ");
+      return content.length === 0
+        ? []
+        : [
+            `<message_id:${message.id}> ${formatSpeaker(message.username, knownPeople)}: ${content}`,
+          ];
+    })
+    .join("\n");
 }
 
 /**
@@ -94,10 +75,10 @@ export function buildUserPrompt(options: UserPromptOptions): string {
   }
 
   if (options.recentContext.length > 0) {
-    sections.push(`Recent context:\n${formatGroupedMessages(options.recentContext, knownPeople)}`);
+    sections.push(`Recent context:\n${formatMessages(options.recentContext, knownPeople)}`);
   }
 
-  sections.push(`New messages:\n${formatGroupedMessages(options.messages, knownPeople)}`);
+  sections.push(`New messages:\n${formatMessages(options.messages, knownPeople)}`);
 
   return sections.join("\n\n");
 }

--- a/src/prompts/system.txt
+++ b/src/prompts/system.txt
@@ -19,6 +19,8 @@ Fit naturally into the server's conversational style:
 
 Multiple people may be talking at the same time. Incoming messages are prefixed with the person who sent them.
 
+Each incoming message also starts with an internal `<message_id:...>` reference. Never include these references in user-visible replies.
+
 Pay attention to who is speaking and which messages belong to which conversation. Address specific people when it helps avoid ambiguity.
 
 Your responses do not need a sender prefix.
@@ -55,6 +57,12 @@ All user-visible Discord responses must be sent with `message`. Do not put Disco
 
 `text` may be one message or an ordered array of messages. Prefer a small array of short, natural messages over one large block when a response contains multiple thoughts, steps, or shifts in tone. Keep closely related sentences together, do not split sentences across messages, and avoid sending many tiny fragments. Use one message for brief, simple responses.
 
+Set `reply_to` to an exact `message_id` only when a visible Discord reply is useful. Otherwise set it to `null`.
+
+Do not use `reply_to` automatically. In particular, when there is only one new incoming message, normally send a regular message with `reply_to: null`. Use a reply when someone explicitly asks you to reply to a message, or when multiple incoming messages, people, or topics make it useful to show exactly which message you are addressing.
+
+When sending multiple messages in one call, only the first message is attached as the reply. Use separate `message` calls if different responses need to reply to different incoming messages.
+
 Action-enabled tools accept these lifecycle fields:
 
 * `next_action`: `continue`, `wait`, `sleep`, or `null`; `null` defaults to `continue`
@@ -63,6 +71,14 @@ Action-enabled tools accept these lifecycle fields:
 Use `continue` when more tool calls are needed in the current turn. Use `wait` to preserve the conversation and pause until new human messages arrive. Use `sleep` when the conversation is complete and its context is no longer useful.
 
 The next action runs only after every message is sent successfully.
+
+## Reactions
+
+Use `react_to_message` when an emoji reaction is a natural lightweight response to a specific message. React sparingly, and prefer a reaction over sending a redundant acknowledgement.
+
+Use only an exact `message_id` shown in the conversation transcript or returned by `message`. Message IDs are internal references and must never appear in user-visible text.
+
+`react_to_message` is action-enabled and supports the same lifecycle fields as `message`.
 
 ## Remembering people
 

--- a/src/testing/RecordingTransport.ts
+++ b/src/testing/RecordingTransport.ts
@@ -1,4 +1,4 @@
-import type { ChatTransport } from "../app/ChatTransport.js";
+import type { ChatTransport, DeliveredMessage } from "../app/ChatTransport.js";
 
 export type RecordedMessage = { channelId: string; text: string };
 
@@ -12,16 +12,19 @@ export class RecordingTransport implements ChatTransport {
   readonly messages: RecordedMessage[] = [];
   readonly typing: string[] = [];
   readonly statuses: RecordedStatus[] = [];
+  private messageSequence = 0;
 
   /**
    * Records one sent message.
    *
    * @param channelId - Destination channel identifier.
    * @param text - Message content.
-   * @returns A promise that resolves after recording.
+   * @returns A deterministic delivered-message identity for later assertions.
    */
-  async sendMessage(channelId: string, text: string): Promise<void> {
+  async sendMessage(channelId: string, text: string): Promise<DeliveredMessage> {
+    this.messageSequence += 1;
     this.messages.push({ channelId, text });
+    return { id: `sent-${String(this.messageSequence)}`, createdAt: this.messageSequence };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add message ID propagation through bot sessions, chat transports, and Discord boundaries
- Enable reaction replies to target the originating Discord message
- Update message formatting, prompts, and transport test fixtures
- Expand coverage across application, Discord, and portable behavior tests

## Testing

- Added and updated unit tests for message IDs, reaction replies, transports, and Discord tool behavior