### PR TITLE
feat: persist Discord custom status

### DIFF
--- a/src/__tests__/portableBehavior.test.ts
+++ b/src/__tests__/portableBehavior.test.ts
@@ -78,6 +78,7 @@ test("builds all optional prompt context in stable order", () => {
     knownPeople: { makan: { name: "Makan" } },
     includeKnownPeople: true,
     currentBotTime: "Monday at noon",
+    currentCustomStatus: "🍕 making pizza",
     pingedByUsername: "makan",
     recentConversationSummaries: [{ summary: "They discussed lunch." }],
   });
@@ -86,6 +87,7 @@ test("builds all optional prompt context in stable order", () => {
     result,
     [
       "Current bot time: Monday at noon.",
+      'Current Discord custom status: "🍕 making pizza".',
       "Known people:\n- makan is Makan",
       "Recent conversations:\n- They discussed lunch.",
       "Ben was pinged by makan (Makan).",
@@ -93,6 +95,16 @@ test("builds all optional prompt context in stable order", () => {
       "New messages:\n<message_id:2> makan (Makan): hello",
     ].join("\n\n"),
   );
+});
+
+test("formats a reset Discord custom status explicitly", () => {
+  const result = buildUserPrompt({
+    recentContext: [],
+    messages: [{ ...messageBase, id: "1", username: "makan", content: "hello" }],
+    currentCustomStatus: null,
+  });
+
+  assert.match(result, /^Current Discord custom status: none\./);
 });
 
 test("loads the copied system prompt and falls back for a missing file", async () => {

--- a/src/app/BotSession.ts
+++ b/src/app/BotSession.ts
@@ -44,6 +44,9 @@ export type BotSessionPersistence = {
   knownPeople?: {
     listForPrompt(): Promise<KnownPeople>;
   };
+  customStatus?: {
+    get(): Promise<string | undefined>;
+  };
 };
 
 export type BotSessionPromptContext = {
@@ -329,6 +332,13 @@ export class BotSession {
         })) ?? [])
       : [];
     const currentBotTime = this.promptContext.getCurrentBotTime?.();
+    const currentCustomStatus =
+      this.persistence.customStatus === undefined
+        ? undefined
+        : ((await this.persistence.customStatus.get().catch((error: unknown) => {
+            this.logger.warn("custom_status.read_failed", { error: String(error) });
+            return undefined;
+          })) ?? null);
     const prompt = buildUserPrompt({
       recentContext,
       messages,
@@ -336,6 +346,7 @@ export class BotSession {
       includeKnownPeople: includeFirstPromptContext,
       recentConversationSummaries,
       ...(currentBotTime === undefined ? {} : { currentBotTime }),
+      ...(currentCustomStatus === undefined ? {} : { currentCustomStatus }),
       ...(includeFirstPromptContext && messages[0] !== undefined
         ? { pingedByUsername: messages[0].username }
         : {}),

--- a/src/app/__tests__/BotSession.test.ts
+++ b/src/app/__tests__/BotSession.test.ts
@@ -287,6 +287,11 @@ test("loads persisted wake context, names speakers each turn, and saves the slee
         return { makan: { name: "Makan A." } };
       },
     },
+    customStatus: {
+      async get() {
+        return "🍕 making pizza";
+      },
+    },
   };
   const { session } = createSession(orchestrator, undefined, undefined, fastTimings, persistence);
   t.after(() => session.stop());
@@ -301,8 +306,10 @@ test("loads persisted wake context, names speakers each turn, and saves the slee
   assert.match(firstPrompt, /Known people:\n- makan is Makan A\./);
   assert.match(firstPrompt, /Ben was pinged by Makan \(Makan A\.\)/);
   assert.match(firstPrompt, /Recent conversations:\n- The group planned dinner\./);
+  assert.match(firstPrompt, /Current Discord custom status: "🍕 making pizza"\./);
   assert.doesNotMatch(secondPrompt, /Known people:/);
   assert.doesNotMatch(secondPrompt, /Recent conversations:/);
+  assert.match(secondPrompt, /Current Discord custom status: "🍕 making pizza"\./);
   assert.match(secondPrompt, /Makan \(Makan A\.\): done/);
   assert.deepEqual(saved, [" Makan and Ben finished catching up. "]);
 });

--- a/src/app/__tests__/Composition.test.ts
+++ b/src/app/__tests__/Composition.test.ts
@@ -65,6 +65,7 @@ class FakeGateway implements DiscordGateway {
   async addReaction() {}
   async sendTyping() {}
   setPresence() {}
+  setCustomStatus() {}
   async registerCommand(): Promise<"registered"> {
     return "registered";
   }

--- a/src/app/createApplication.ts
+++ b/src/app/createApplication.ts
@@ -13,6 +13,7 @@ import { createScheduledMessageTool } from "../discord/tools/createScheduledMess
 import { createRememberNameTool } from "../discord/tools/rememberName.js";
 import { createReactToMessageTool } from "../discord/tools/reactToMessage.js";
 import { createSendMessageTool } from "../discord/tools/sendChannelMessage.js";
+import { createUpdateCustomStatusTool } from "../discord/tools/updateCustomStatus.js";
 import type { Model } from "../model/Model.js";
 import { OpenAIUsageStore } from "../model/openai/OpenAIUsageStore.js";
 import { formatBotTime } from "../scheduling/scheduleTime.js";
@@ -21,6 +22,7 @@ import {
   SCHEDULE_TIME_ZONE,
 } from "../scheduling/ScheduledMessageScheduler.js";
 import { ConversationSummaryStore } from "../storage/ConversationSummaryStore.js";
+import { CustomStatusStore } from "../storage/CustomStatusStore.js";
 import { KnownPeopleStore } from "../storage/KnownPeopleStore.js";
 import { ScheduledMessageStore } from "../storage/ScheduledMessageStore.js";
 import { ToolRegistry } from "../tools/ToolRegistry.js";
@@ -30,6 +32,7 @@ const paths = {
   summaries: "logs/conversation-summaries.json",
   people: "logs/known-people.json",
   schedules: "logs/scheduled-messages.json",
+  customStatus: "logs/custom-status.json",
 } as const;
 
 export type Application = {
@@ -79,6 +82,7 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
   const summaries = new ConversationSummaryStore(paths.summaries, logger);
   const people = new KnownPeopleStore(paths.people, logger);
   const schedules = new ScheduledMessageStore(paths.schedules, logger);
+  const customStatus = new CustomStatusStore(paths.customStatus, logger);
   const scheduledScheduler = new ScheduledMessageScheduler(
     schedules,
     createScheduledMessageDelivery(gateway),
@@ -113,6 +117,14 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
     }),
   );
   tools.register(
+    createUpdateCustomStatusTool({
+      gateway,
+      store: customStatus,
+      getActiveChannelId: () => session.getActiveChannelId(),
+      logger,
+    }),
+  );
+  tools.register(
     createScheduledMessageTool({
       gateway,
       users,
@@ -131,13 +143,14 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
     presence,
     logger,
     {},
-    { summaries, knownPeople: people },
+    { summaries, knownPeople: people, customStatus },
     {
       getCurrentBotTime: () => formatBotTime(new Date(), SCHEDULE_TIME_ZONE),
     },
   );
 
   let ready = false;
+  let restoredCustomStatus: string | undefined;
   const adapter = new DiscordAdapter(
     gateway,
     {
@@ -148,6 +161,11 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
         if (ready) return;
         ready = true;
         presence.setPresence({ status: "idle" });
+        try {
+          gateway.setCustomStatus(restoredCustomStatus);
+        } catch (error) {
+          logger.warn("discord.custom_status_restore_failed", { error: String(error) });
+        }
         void scheduledScheduler.start();
         void registerUsageCommand(gateway, logger).catch((error: unknown) => {
           logger.warn("discord.command_registration_failed", { error: String(error) });
@@ -163,7 +181,10 @@ export function createApplication(dependencies: ApplicationDependencies): Applic
   );
 
   return {
-    start: () => adapter.start(env.discordToken),
+    async start() {
+      restoredCustomStatus = await customStatus.get();
+      await adapter.start(env.discordToken);
+    },
     async stop() {
       session.stop();
       scheduledScheduler.stop();

--- a/src/discord/DiscordGateway.ts
+++ b/src/discord/DiscordGateway.ts
@@ -74,5 +74,6 @@ export type DiscordGateway = {
   addReaction(channelId: string, messageId: string, emoji: string): Promise<void>;
   sendTyping(channelId: string): Promise<void>;
   setPresence(status: "idle" | "online"): void;
+  setCustomStatus(content: string | undefined): void;
   registerCommand(command: DiscordCommandDefinition): Promise<"registered" | "updated">;
 };

--- a/src/discord/DiscordJsGateway.ts
+++ b/src/discord/DiscordJsGateway.ts
@@ -1,4 +1,4 @@
-import { Client, Events, GatewayIntentBits } from "discord.js";
+import { ActivityType, Client, Events, GatewayIntentBits } from "discord.js";
 
 import type {
   DiscordChannel,
@@ -214,6 +214,17 @@ export class DiscordJsGateway implements DiscordGateway {
    */
   setPresence(status: "idle" | "online"): void {
     this.client.user?.setPresence({ status });
+  }
+
+  /**
+   * Sets or clears Ben's custom status activity without changing availability.
+   *
+   * @param content - Custom status text, or `undefined` to clear the activity.
+   */
+  setCustomStatus(content: string | undefined): void {
+    this.client.user?.setPresence({
+      activities: content === undefined ? [] : [{ name: content, type: ActivityType.Custom }],
+    });
   }
 
   /**

--- a/src/discord/__tests__/DiscordBoundary.test.ts
+++ b/src/discord/__tests__/DiscordBoundary.test.ts
@@ -203,6 +203,7 @@ class FakeDiscordGateway implements DiscordGateway {
   sent: Array<{ channelId: string; content: string; options: DiscordSendOptions }> = [];
   typing: string[] = [];
   presences: Array<"idle" | "online"> = [];
+  customStatuses: Array<string | undefined> = [];
   memberSearches: Array<{ guildId: string; query: string }> = [];
   reactions: Array<{ channelId: string; messageId: string; emoji: string }> = [];
 
@@ -240,6 +241,9 @@ class FakeDiscordGateway implements DiscordGateway {
   }
   setPresence(status: "idle" | "online"): void {
     this.presences.push(status);
+  }
+  setCustomStatus(content: string | undefined): void {
+    this.customStatuses.push(content);
   }
   async registerCommand(): Promise<"registered"> {
     return "registered";

--- a/src/discord/__tests__/DiscordTools.test.ts
+++ b/src/discord/__tests__/DiscordTools.test.ts
@@ -23,6 +23,7 @@ import { createScheduledMessageTool } from "../tools/createScheduledMessage.js";
 import { createReactToMessageTool } from "../tools/reactToMessage.js";
 import { createRememberNameTool } from "../tools/rememberName.js";
 import { createSendMessageTool } from "../tools/sendChannelMessage.js";
+import { createUpdateCustomStatusTool } from "../tools/updateCustomStatus.js";
 
 const general: DiscordChannel = { id: "general", name: "general", guildId: "guild" };
 const plans: DiscordChannel = { id: "plans", name: "plans", guildId: "guild" };
@@ -93,6 +94,73 @@ test("remember-name controls empty, ambiguous, duplicate, and lookup failures", 
     JSON.stringify(await execute(create(), { username: "sam", name: "Sam" })),
     /Discord unavailable/,
   );
+});
+
+test("custom-status tool sets, resets, and reports the global status", async () => {
+  const gateway = new FakeGateway();
+  const tool = createUpdateCustomStatusTool({
+    gateway,
+    store: {
+      async set(status) {
+        gateway.storedCustomStatuses.push(status);
+      },
+    },
+    getActiveChannelId: () => "general",
+    logger,
+  });
+
+  assert.deepEqual(await execute(tool, { emoji: " 🍕 ", content: " making   pizza " }), {
+    type: "continue",
+    result: { ok: true, emoji: "🍕", content: "making pizza", reset: false },
+  });
+  assert.deepEqual(await execute(tool, { emoji: "🤔", content: null }), {
+    type: "continue",
+    result: { ok: true, emoji: "🤔", content: null, reset: false },
+  });
+  assert.deepEqual(await execute(tool, { emoji: null, content: " thinking " }), {
+    type: "continue",
+    result: { ok: true, emoji: null, content: "thinking", reset: false },
+  });
+  assert.deepEqual(await execute(tool, { emoji: null, content: null }), {
+    type: "continue",
+    result: { ok: true, emoji: null, content: null, reset: true },
+  });
+  assert.deepEqual(gateway.customStatuses, ["🍕 making pizza", "🤔", "thinking", undefined]);
+  assert.deepEqual(gateway.storedCustomStatuses, ["🍕 making pizza", "🤔", "thinking", undefined]);
+  assert.deepEqual(
+    gateway.sent.map(({ content }) => content),
+    [
+      '> Updated my status to "🍕 making pizza"',
+      '> Updated my status to "🤔"',
+      '> Updated my status to "thinking"',
+      "> Reset my status",
+    ],
+  );
+});
+
+test("custom-status tool reports validation and Discord failures", async () => {
+  const gateway = new FakeGateway();
+  const tool = createUpdateCustomStatusTool({
+    gateway,
+    store: {
+      async set(status) {
+        gateway.storedCustomStatuses.push(status);
+      },
+    },
+    getActiveChannelId: () => "general",
+    logger,
+  });
+
+  assert.match(
+    JSON.stringify(await execute(tool, { emoji: "x".repeat(33), content: null })),
+    /at most 32/,
+  );
+  gateway.customStatusError = new Error("Discord unavailable");
+  assert.match(
+    JSON.stringify(await execute(tool, { emoji: null, content: "thinking" })),
+    /Discord unavailable/,
+  );
+  assert.match(gateway.sent.at(-1)?.content ?? "", /^> ⚠️ Failed to update my status/);
 });
 
 test("message sends one or more messages and defaults to continuing", async () => {
@@ -364,10 +432,17 @@ test("Discord capability tools register through the generic tool registry", () =
     getActiveChannelId: () => "general",
     isMessageInActiveConversation: () => true,
   });
+  const updateCustomStatus = createUpdateCustomStatusTool({
+    gateway,
+    store: { async set() {} },
+    getActiveChannelId: () => "general",
+    logger,
+  });
   const registry = new ToolRegistry([
     sendMessage,
     reactToMessage,
     rememberName,
+    updateCustomStatus,
     scheduledMessage,
     waitTool,
     sleepTool,
@@ -375,7 +450,15 @@ test("Discord capability tools register through the generic tool registry", () =
 
   assert.deepEqual(
     registry.definitions().map(({ name }) => name),
-    ["message", "react_to_message", "remember_name", "create_scheduled_message", "wait", "sleep"],
+    [
+      "message",
+      "react",
+      "remember_name",
+      "update_status",
+      "create_scheduled_message",
+      "wait",
+      "sleep",
+    ],
   );
 });
 
@@ -462,6 +545,9 @@ class FakeGateway implements DiscordGateway {
   memberError: unknown;
   sent: Array<{ channelId: string; content: string; options: DiscordSendOptions }> = [];
   reactions: Array<{ channelId: string; messageId: string; emoji: string }> = [];
+  customStatuses: Array<string | undefined> = [];
+  storedCustomStatuses: Array<string | undefined> = [];
+  customStatusError: unknown;
   setHandlers(_handlers: DiscordGatewayHandlers): void {}
   async login(_token: string): Promise<void> {}
   async destroy(): Promise<void> {}
@@ -487,6 +573,10 @@ class FakeGateway implements DiscordGateway {
   }
   async sendTyping(_channelId: string): Promise<void> {}
   setPresence(_status: "idle" | "online"): void {}
+  setCustomStatus(content: string | undefined): void {
+    if (this.customStatusError !== undefined) throw this.customStatusError;
+    this.customStatuses.push(content);
+  }
   async registerCommand(): Promise<"registered"> {
     return "registered";
   }

--- a/src/discord/tools/reactToMessage.ts
+++ b/src/discord/tools/reactToMessage.ts
@@ -20,7 +20,7 @@ export type ReactToMessageToolDependencies = {
 export function createReactToMessageTool(dependencies: ReactToMessageToolDependencies): Tool {
   return createActionableTool({
     definition: {
-      name: "react_to_message",
+      name: "react",
       description:
         "Add one emoji reaction to a message from the active conversation using its exact message_id.",
       parameters: {

--- a/src/discord/tools/updateCustomStatus.ts
+++ b/src/discord/tools/updateCustomStatus.ts
@@ -1,0 +1,98 @@
+import type { Logger } from "../../logger.js";
+import type { Tool, ToolResult } from "../../tools/Tool.js";
+import type { DiscordGateway } from "../DiscordGateway.js";
+import { parseArguments, sanitizeText, sendToolStatus, toolFailure } from "./toolSupport.js";
+
+const MAX_EMOJI_LENGTH = 32;
+const MAX_STATUS_LENGTH = 128;
+
+export type UpdateCustomStatusToolDependencies = {
+  gateway: Pick<DiscordGateway, "sendMessage" | "setCustomStatus">;
+  store: { set(status: string | undefined): Promise<void> };
+  getActiveChannelId(): string | undefined;
+  logger: Pick<Logger, "warn">;
+};
+
+/**
+ * Creates the Discord-backed, non-terminal custom-status capability tool.
+ *
+ * @param dependencies - Presence delivery, active-session, and status-reporting capabilities.
+ * @returns A tool that sets or clears Ben's custom status and reports the result in-channel.
+ */
+export function createUpdateCustomStatusTool(
+  dependencies: UpdateCustomStatusToolDependencies,
+): Tool {
+  return {
+    definition: {
+      name: "update_status",
+      description:
+        "Set Ben's global Discord custom status using an optional Unicode emoji and content, or clear it when both are null.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          emoji: {
+            type: ["string", "null"],
+            maxLength: MAX_EMOJI_LENGTH,
+            description: "Optional Unicode emoji displayed before the status content.",
+          },
+          content: {
+            type: ["string", "null"],
+            maxLength: MAX_STATUS_LENGTH,
+            description: "Optional custom status text.",
+          },
+        },
+        required: ["emoji", "content"],
+      },
+    },
+    async execute(call) {
+      const input = parseArguments(call.arguments);
+      const emoji = sanitizeText(input.emoji, true);
+      const content = sanitizeText(input.content, true);
+      const display = [emoji, content].filter((part) => part.length > 0).join(" ");
+      const channelId = dependencies.getActiveChannelId();
+      const fail = async (error: string): Promise<ToolResult> => {
+        await sendToolStatus(
+          dependencies.gateway,
+          dependencies.logger,
+          "discord.custom_status_message_failed",
+          channelId,
+          `> ⚠️ Failed to update my status: ${error}`,
+        );
+        return toolFailure(error);
+      };
+
+      if (emoji.length > MAX_EMOJI_LENGTH) {
+        return fail(`emoji must contain at most ${String(MAX_EMOJI_LENGTH)} characters`);
+      }
+      if (display.length > MAX_STATUS_LENGTH) {
+        return fail(`combined status must contain at most ${String(MAX_STATUS_LENGTH)} characters`);
+      }
+      if (channelId === undefined) return fail("no active Discord channel");
+
+      try {
+        const status = display.length === 0 ? undefined : display;
+        await dependencies.store.set(status);
+        dependencies.gateway.setCustomStatus(status);
+        await sendToolStatus(
+          dependencies.gateway,
+          dependencies.logger,
+          "discord.custom_status_message_failed",
+          channelId,
+          display.length === 0 ? "> Reset my status" : `> Updated my status to "${display}"`,
+        );
+        return {
+          type: "continue",
+          result: {
+            ok: true,
+            emoji: emoji.length === 0 ? null : emoji,
+            content: content.length === 0 ? null : content,
+            reset: display.length === 0,
+          },
+        };
+      } catch (error) {
+        return fail(String(error));
+      }
+    },
+  };
+}

--- a/src/prompts/formatMessages.ts
+++ b/src/prompts/formatMessages.ts
@@ -12,6 +12,7 @@ export type UserPromptOptions = {
   knownPeople?: KnownPeople;
   includeKnownPeople?: boolean;
   currentBotTime?: string;
+  currentCustomStatus?: string | null;
   pingedByUsername?: string;
   recentConversationSummaries?: readonly ConversationSummary[];
 };
@@ -51,6 +52,14 @@ export function buildUserPrompt(options: UserPromptOptions): string {
 
   if (options.currentBotTime !== undefined) {
     sections.push(`Current bot time: ${options.currentBotTime}.`);
+  }
+
+  if (options.currentCustomStatus !== undefined) {
+    sections.push(
+      options.currentCustomStatus === null
+        ? "Current Discord custom status: none."
+        : `Current Discord custom status: ${JSON.stringify(options.currentCustomStatus)}.`,
+    );
   }
 
   if (options.includeKnownPeople === true) {

--- a/src/prompts/system.txt
+++ b/src/prompts/system.txt
@@ -74,11 +74,11 @@ The next action runs only after every message is sent successfully.
 
 ## Reactions
 
-Use `react_to_message` when an emoji reaction is a natural lightweight response to a specific message. React sparingly, and prefer a reaction over sending a redundant acknowledgement.
+Use `react` when an emoji reaction is a natural lightweight response to a specific message. React sparingly, and prefer a reaction over sending a redundant acknowledgement.
 
 Use only an exact `message_id` shown in the conversation transcript or returned by `message`. Message IDs are internal references and must never appear in user-visible text.
 
-`react_to_message` is action-enabled and supports the same lifecycle fields as `message`.
+`react` is action-enabled and supports the same lifecycle fields as `message`.
 
 ## Remembering people
 
@@ -87,6 +87,16 @@ When someone clearly tells you that a Discord username belongs to a real person,
 Do not announce whether remembering succeeded or failed. The server handles that status itself.
 
 `remember_name` is not terminal.
+
+## Custom status
+
+Use `update_status` when someone asks you to set, change, or reset your Discord custom status. The status is global rather than specific to the current channel.
+
+Pass a Unicode emoji, content, or both. Pass `null` for both fields to reset the status.
+
+Do not separately announce whether updating the status succeeded or failed. The server reports that status itself.
+
+`update_status` is not terminal.
 
 ## Scheduled messages and reminders
 

--- a/src/storage/CustomStatusStore.ts
+++ b/src/storage/CustomStatusStore.ts
@@ -1,0 +1,59 @@
+import type { Logger } from "../logger.js";
+import { isRecord, readJsonFile, UpdateQueue, writeJsonFileAtomic } from "./JsonFile.js";
+
+/** Persists the rendered Discord custom status restored across bot restarts. */
+export class CustomStatusStore {
+  private readonly updates = new UpdateQueue();
+
+  /**
+   * Creates a store over Ben's custom-status file.
+   *
+   * @param filePath - JSON file containing the current rendered status.
+   * @param logger - Logger used when malformed stored data is ignored.
+   */
+  constructor(
+    private readonly filePath: string,
+    private readonly logger: Pick<Logger, "warn">,
+  ) {}
+
+  /**
+   * Gets the current custom status.
+   *
+   * @returns The rendered status, or `undefined` when it is reset or unavailable.
+   */
+  async get(): Promise<string | undefined> {
+    return this.updates.run(async () => {
+      try {
+        const parsed = await readJsonFile(this.filePath);
+        if (parsed === undefined) return undefined;
+        if (!isRecord(parsed) || (parsed.status !== null && typeof parsed.status !== "string")) {
+          this.logger.warn("custom_status.invalid", { path: this.filePath });
+          return undefined;
+        }
+        const status = parsed.status?.trim();
+        return status === undefined || status.length === 0 ? undefined : status;
+      } catch (error) {
+        this.logger.warn("custom_status.read_failed", {
+          path: this.filePath,
+          error: String(error),
+        });
+        return undefined;
+      }
+    });
+  }
+
+  /**
+   * Atomically stores or resets the current custom status.
+   *
+   * @param status - Rendered status text, or `undefined` to persist a reset.
+   * @returns A promise that resolves after the status is durably stored.
+   */
+  async set(status: string | undefined): Promise<void> {
+    await this.updates.run(() =>
+      writeJsonFileAtomic(this.filePath, {
+        version: 1,
+        status: status ?? null,
+      }),
+    );
+  }
+}

--- a/src/storage/__tests__/PersistenceStores.test.ts
+++ b/src/storage/__tests__/PersistenceStores.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { ConversationSummaryStore } from "../ConversationSummaryStore.js";
+import { CustomStatusStore } from "../CustomStatusStore.js";
 import { KnownPeopleStore } from "../KnownPeopleStore.js";
 import { ScheduledMessageStore } from "../ScheduledMessageStore.js";
 
@@ -14,6 +15,34 @@ const logger = {
     warnings.push(event);
   },
 };
+
+test("custom-status store atomically persists and resets the rendered status", async (t) => {
+  const directory = await tempDirectory(t);
+  const filePath = path.join(directory, "custom-status.json");
+  const store = new CustomStatusStore(filePath, logger);
+
+  assert.equal(await store.get(), undefined);
+  await store.set("🍕 making pizza");
+  assert.equal(await store.get(), "🍕 making pizza");
+  assert.deepEqual(JSON.parse(await readFile(filePath, "utf8")), {
+    version: 1,
+    status: "🍕 making pizza",
+  });
+  await store.set(undefined);
+  assert.equal(await store.get(), undefined);
+  assert.deepEqual(await readdir(directory), ["custom-status.json"]);
+});
+
+test("custom-status store contains malformed data", async (t) => {
+  const directory = await tempDirectory(t);
+  const filePath = path.join(directory, "custom-status.json");
+  const store = new CustomStatusStore(filePath, logger);
+
+  await writeFile(filePath, JSON.stringify({ status: 42 }));
+  assert.equal(await store.get(), undefined);
+  await writeFile(filePath, "not json");
+  assert.equal(await store.get(), undefined);
+});
 
 test("summary store reads the current shape, bounds entries, and writes atomically", async (t) => {
   const directory = await tempDirectory(t);


### PR DESCRIPTION
## Summary

- add an `update_status` tool that sets or resets Ben's Discord custom status and reports the outcome in-channel
- persist the rendered status atomically and restore it when Discord becomes ready
- include the current custom status in newly built user prompts without mutating prior conversation history
- shorten the reaction tool's exposed name from `react_to_message` to `react`

## Impact

Ben can keep a custom status across restarts, knows the current status in subsequent model turns, and uses shorter model-facing tool names.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (90 passing)