### PR TITLE
feat: increase model reasoning effort

### DIFF
--- a/src/model/openai/OpenAIModel.ts
+++ b/src/model/openai/OpenAIModel.ts
@@ -80,7 +80,7 @@ export class OpenAIModel implements Model {
         ? {}
         : { tools, tool_choice: "required" as const, parallel_tool_calls: false }),
       max_output_tokens: this.maxOutputTokens,
-      reasoning: { effort: "medium" },
+      reasoning: { effort: "high" },
       include: ["reasoning.encrypted_content"],
       store: false,
     });

--- a/src/model/openai/__tests__/OpenAIModel.test.ts
+++ b/src/model/openai/__tests__/OpenAIModel.test.ts
@@ -48,7 +48,7 @@ test("makes one configured request, maps its turn, and records usage", async (co
     tool_choice: "required",
     parallel_tool_calls: false,
     max_output_tokens: 512,
-    reasoning: { effort: "medium" },
+    reasoning: { effort: "high" },
     include: ["reasoning.encrypted_content"],
     store: false,
   });


### PR DESCRIPTION
## Summary

- increase the OpenAI model reasoning effort from `medium` to `high`
- update the request-shape test expectation

## Testing

- `pnpm exec node --import tsx --test src/model/openai/__tests__/OpenAIModel.test.ts`
- `pnpm typecheck`
- `pnpm lint`