### PR TITLE
feat: expand memory consolidation capacity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export async function createDefaultApplication(): Promise<Application> {
     usageStore,
     conversationModel: new OpenAIModel({ apiKey: env.openaiApiKey }, usageStore),
     consolidationModel: new OpenAIModel(
-      { apiKey: env.openaiApiKey, maxOutputTokens: 2_048 },
+      { apiKey: env.openaiApiKey, maxOutputTokens: 8_192, reasoningEffort: "xhigh" },
       usageStore,
     ),
     instructions,

--- a/src/model/openai/OpenAIModel.ts
+++ b/src/model/openai/OpenAIModel.ts
@@ -3,6 +3,7 @@ import type {
   Response,
   ResponseCreateParamsNonStreaming,
 } from "openai/resources/responses/responses";
+import type { ReasoningEffort } from "openai/resources/shared";
 
 import {
   ModelBudgetExceededError,
@@ -25,12 +26,14 @@ export type OpenAIModelOptions = {
   apiKey: string;
   model?: string;
   maxOutputTokens?: number;
+  reasoningEffort?: Exclude<ReasoningEffort, null>;
 };
 
 /** Implements the provider-neutral model contract with the OpenAI Responses API. */
 export class OpenAIModel implements Model {
   private readonly model: string;
   private readonly maxOutputTokens: number;
+  private readonly reasoningEffort: Exclude<ReasoningEffort, null>;
   private readonly responses: ResponsesClient;
   private readonly mapper = new OpenAIMapper();
 
@@ -49,6 +52,7 @@ export class OpenAIModel implements Model {
   ) {
     this.model = options.model ?? OPENAI_CONVERSATION_MODEL;
     this.maxOutputTokens = options.maxOutputTokens ?? MAX_OUTPUT_TOKENS;
+    this.reasoningEffort = options.reasoningEffort ?? "high";
     this.responses = responses ?? new OpenAI({ apiKey: options.apiKey }).responses;
     getModelPricing(this.model);
 
@@ -80,7 +84,7 @@ export class OpenAIModel implements Model {
         ? {}
         : { tools, tool_choice: "required" as const, parallel_tool_calls: false }),
       max_output_tokens: this.maxOutputTokens,
-      reasoning: { effort: "high" },
+      reasoning: { effort: this.reasoningEffort },
       include: ["reasoning.encrypted_content"],
       store: false,
     });

--- a/src/model/openai/__tests__/OpenAIModel.test.ts
+++ b/src/model/openai/__tests__/OpenAIModel.test.ts
@@ -86,22 +86,26 @@ test("supports requests without forcing a tool call", async (context) => {
   const directory = await createTempDirectory(context);
   const usageStore = new OpenAIUsageStore(directory, "gpt-5.4-mini", 0);
   let request: ResponseCreateParamsNonStreaming | undefined;
-  const model = new OpenAIModel({ apiKey: "test", maxOutputTokens: 96 }, usageStore, {
-    async create(params): Promise<Response> {
-      request = params;
-      return {
-        output: [
-          {
-            id: "message-1",
-            type: "message",
-            role: "assistant",
-            status: "completed",
-            content: [{ type: "output_text", text: "hello", annotations: [] }],
-          },
-        ],
-      } as unknown as Response;
+  const model = new OpenAIModel(
+    { apiKey: "test", maxOutputTokens: 8_192, reasoningEffort: "xhigh" },
+    usageStore,
+    {
+      async create(params): Promise<Response> {
+        request = params;
+        return {
+          output: [
+            {
+              id: "message-1",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "hello", annotations: [] }],
+            },
+          ],
+        } as unknown as Response;
+      },
     },
-  });
+  );
 
   const turn = await model.invoke({
     instructions: "Be concise.",
@@ -111,6 +115,8 @@ test("supports requests without forcing a tool call", async (context) => {
 
   assert.equal("tools" in (request ?? {}), false);
   assert.equal("tool_choice" in (request ?? {}), false);
+  assert.equal(request?.max_output_tokens, 8_192);
+  assert.deepEqual(request?.reasoning, { effort: "xhigh" });
   assert.deepEqual(turn.items, [{ type: "message", role: "assistant", text: "hello" }]);
 });
 


### PR DESCRIPTION
## Summary

- raise memory consolidation output capacity from 2,048 to 8,192 tokens
- make reasoning effort configurable per OpenAI model instance
- use xhigh reasoning for consolidation while preserving messaging defaults
- cover the consolidation request overrides in adapter tests

## Validation

- pnpm format:check
- pnpm typecheck
- pnpm test (116 passing)
- pnpm lint