### PR TITLE
feat: show uncached input in usage

### DIFF
--- a/src/discord/__tests__/UsageCommand.test.ts
+++ b/src/discord/__tests__/UsageCommand.test.ts
@@ -19,7 +19,7 @@ const summary = {
 test("formats limited and unlimited daily usage", () => {
   assert.equal(
     formatUsageSummary(summary),
-    "1,234/200/50 (input/cached/output) - $0.2500 (25.0%) - gpt-5.4-mini",
+    "1,034/200/50 (uncached/cached/output) - $0.2500 (25.0%) - gpt-5.4-mini",
   );
   assert.match(formatUsageSummary({ ...summary, budgetUsd: 0 }), /\(n\/a\)/);
 });

--- a/src/discord/usageCommand.ts
+++ b/src/discord/usageCommand.ts
@@ -51,7 +51,8 @@ export async function handleUsageCommand(
  * @returns Compact user-facing usage text.
  */
 export function formatUsageSummary(summary: UsageSummary): string {
-  return `${formatInteger(summary.inputTokens)}/${formatInteger(summary.cachedInputTokens)}/${formatInteger(summary.outputTokens)} (input/cached/output) - ${formatUsd(summary.costUsd)} (${formatUsagePercent(summary)}) - ${summary.model}`;
+  const uncachedInputTokens = Math.max(0, summary.inputTokens - summary.cachedInputTokens);
+  return `${formatInteger(uncachedInputTokens)}/${formatInteger(summary.cachedInputTokens)}/${formatInteger(summary.outputTokens)} (uncached/cached/output) - ${formatUsd(summary.costUsd)} (${formatUsagePercent(summary)}) - ${summary.model}`;
 }
 
 /** Formats an integer with locale-appropriate grouping separators. */


### PR DESCRIPTION
## Summary

- derive uncached input tokens from the existing total and cached counters
- label the `/usage` breakdown as `uncached/cached/output`
- update the usage command test expectation

## Validation

- `pnpm test` (116 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`